### PR TITLE
Prevent ensure(...) calls missing chained assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ensure
-A balanced test framework for Go 1.13+.
+A balanced test framework for Go 1.14+.
 
 [![Documentation](https://pkg.go.dev/badge/github.com/JosiahWitt/ensure)](https://pkg.go.dev/github.com/JosiahWitt/ensure)
 [![CI](https://github.com/JosiahWitt/ensure/workflows/CI/badge.svg)](https://github.com/JosiahWitt/ensure/actions?query=branch%3Amaster+workflow%3ACI)
@@ -58,10 +58,13 @@ func TestBasicExample(t *testing.T) {
     // To ensure a value is correct, use ensure as a function:
     ensure("abc").Equals("abc")
     ensure(produceError()).IsError(expectedError)
+    ensure(doNotProduceError()).IsNotError()
     ensure(true).IsTrue()
     ensure(false).IsFalse()
+    ensure("").IsEmpty()
 
-    ensure.Fail()
+    // Failing a test directly:
+    ensure.Failf("Something went wrong, and we stop the test immediately")
   })
 }
 ```

--- a/ensure.go
+++ b/ensure.go
@@ -1,4 +1,4 @@
-// Package ensure is a balanced testing framework.
+// Package ensure is a balanced testing framework for Go 1.14+.
 // It supports modern Go 1.13+ error comparisons (via errors.Is), and provides easy to read diffs (via deep.Equal).
 //
 // Most of the implementation is in the ensurepkg package.
@@ -18,10 +18,13 @@
 //   	 // To ensure a value is correct, use ensure as a function:
 //   	 ensure("abc").Equals("abc")
 //   	 ensure(produceError()).IsError(expectedError)
+//   	 ensure(doNotProduceError()).IsNotError()
 //   	 ensure(true).IsTrue()
 //   	 ensure(false).IsFalse()
+//   	 ensure("").IsEmpty()
 //
-//   	 ensure.Fail()
+//     // Failing a test directly:
+//     ensure.Failf("Something went wrong, and we stop the test immediately")
 //   })
 //  }
 package ensure

--- a/ensurepkg/chain_test.go
+++ b/ensurepkg/chain_test.go
@@ -6,15 +6,12 @@ import (
 	"testing"
 
 	"github.com/JosiahWitt/ensure"
-	"github.com/JosiahWitt/ensure/internal/mocks/mock_ensurepkg"
 	"github.com/JosiahWitt/erk"
-	"github.com/golang/mock/gomock"
 )
 
 func TestChainIsTrue(t *testing.T) {
 	t.Run("when true", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 		mockT.EXPECT().Helper()
 
 		ensure := ensure.New(mockT)
@@ -22,10 +19,9 @@ func TestChainIsTrue(t *testing.T) {
 	})
 
 	t.Run("when false", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 
-		mockT.EXPECT().Errorf("Got false, expected true").After(
+		mockT.EXPECT().Fatalf("Got false, expected true").After(
 			mockT.EXPECT().Helper(),
 		)
 
@@ -34,11 +30,10 @@ func TestChainIsTrue(t *testing.T) {
 	})
 
 	t.Run("when not a boolean", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 
 		const val = "not a boolean"
-		mockT.EXPECT().Errorf("Got type %T, expected boolean", val).After(
+		mockT.EXPECT().Fatalf("Got type %T, expected boolean", val).After(
 			mockT.EXPECT().Helper(),
 		)
 
@@ -49,8 +44,7 @@ func TestChainIsTrue(t *testing.T) {
 
 func TestChainIsFalse(t *testing.T) {
 	t.Run("when false", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 		mockT.EXPECT().Helper()
 
 		ensure := ensure.New(mockT)
@@ -58,10 +52,9 @@ func TestChainIsFalse(t *testing.T) {
 	})
 
 	t.Run("when true", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 
-		mockT.EXPECT().Errorf("Got true, expected false").After(
+		mockT.EXPECT().Fatalf("Got true, expected false").After(
 			mockT.EXPECT().Helper(),
 		)
 
@@ -70,11 +63,10 @@ func TestChainIsFalse(t *testing.T) {
 	})
 
 	t.Run("when not a boolean", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 
 		const val = "not a boolean"
-		mockT.EXPECT().Errorf("Got type %T, expected boolean", val).After(
+		mockT.EXPECT().Fatalf("Got type %T, expected boolean", val).After(
 			mockT.EXPECT().Helper(),
 		)
 
@@ -85,8 +77,7 @@ func TestChainIsFalse(t *testing.T) {
 
 func TestChainIsNil(t *testing.T) {
 	t.Run("when nil", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 		mockT.EXPECT().Helper()
 
 		ensure := ensure.New(mockT)
@@ -94,8 +85,7 @@ func TestChainIsNil(t *testing.T) {
 	})
 
 	t.Run("when nil pointer", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 		mockT.EXPECT().Helper()
 
 		var nilPtr *string
@@ -105,11 +95,10 @@ func TestChainIsNil(t *testing.T) {
 	})
 
 	t.Run("when not nil", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 
 		const val = "not nil"
-		mockT.EXPECT().Errorf("Got %+v, expected nil", val).After(
+		mockT.EXPECT().Fatalf("Got %+v, expected nil", val).After(
 			mockT.EXPECT().Helper(),
 		)
 
@@ -134,8 +123,7 @@ func TestChainEquals(t *testing.T) {
 	}
 
 	t.Run("when equal", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 		mockT.EXPECT().Helper()
 
 		ensure := ensure.New(mockT)
@@ -143,8 +131,7 @@ func TestChainEquals(t *testing.T) {
 	})
 
 	t.Run("when unexported field is equal", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 		mockT.EXPECT().Helper()
 
 		ensure := ensure.New(mockT)
@@ -152,8 +139,7 @@ func TestChainEquals(t *testing.T) {
 	})
 
 	t.Run("when both are nil", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 		mockT.EXPECT().Helper()
 
 		ensure := ensure.New(mockT)
@@ -161,8 +147,7 @@ func TestChainEquals(t *testing.T) {
 	})
 
 	t.Run("when nil pointer equals nil", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 		mockT.EXPECT().Helper()
 
 		var nilPtr *string
@@ -172,8 +157,7 @@ func TestChainEquals(t *testing.T) {
 	})
 
 	t.Run("when nil map equals empty map", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 		mockT.EXPECT().Helper()
 
 		var nilMap map[string]string
@@ -183,8 +167,7 @@ func TestChainEquals(t *testing.T) {
 	})
 
 	t.Run("when nil slice equals empty slice", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 		mockT.EXPECT().Helper()
 
 		var nilMap []string
@@ -194,8 +177,7 @@ func TestChainEquals(t *testing.T) {
 	})
 
 	t.Run("when nil array equals empty array", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 		mockT.EXPECT().Helper()
 
 		var nilMap [2]string
@@ -205,9 +187,8 @@ func TestChainEquals(t *testing.T) {
 	})
 
 	t.Run("when one field is not equal", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
-		mockT.EXPECT().Errorf(errorMessageFormat,
+		mockT := setupMockTWithCleanupCheck(t)
+		mockT.EXPECT().Fatalf(errorMessageFormat,
 			"Actual does not equal expected:\n - Name: John != Sam",
 			Person{Name: "John", Email: "john@test"},
 			Person{Name: "Sam", Email: "john@test"},
@@ -220,9 +201,8 @@ func TestChainEquals(t *testing.T) {
 	})
 
 	t.Run("when not equal: expected is nil", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
-		mockT.EXPECT().Errorf(errorMessageFormat,
+		mockT := setupMockTWithCleanupCheck(t)
+		mockT.EXPECT().Fatalf(errorMessageFormat,
 			"Actual does not equal expected:\n - {John john@test  []} != <nil pointer>",
 			Person{Name: "John", Email: "john@test"},
 			nil,
@@ -235,9 +215,8 @@ func TestChainEquals(t *testing.T) {
 	})
 
 	t.Run("when not equal: actual is nil", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
-		mockT.EXPECT().Errorf(errorMessageFormat,
+		mockT := setupMockTWithCleanupCheck(t)
+		mockT.EXPECT().Fatalf(errorMessageFormat,
 			"Actual does not equal expected:\n - <nil pointer> != {John john@test  []}",
 			nil,
 			Person{Name: "John", Email: "john@test"},
@@ -250,9 +229,8 @@ func TestChainEquals(t *testing.T) {
 	})
 
 	t.Run("when unexported field is not equal", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
-		mockT.EXPECT().Errorf(errorMessageFormat,
+		mockT := setupMockTWithCleanupCheck(t)
+		mockT.EXPECT().Fatalf(errorMessageFormat,
 			"Actual does not equal expected:\n - ssn: 123456789 != 123456780",
 			Person{Name: "John", Email: "john@test", ssn: "123456789"},
 			Person{Name: "John", Email: "john@test", ssn: "123456780"},
@@ -265,9 +243,8 @@ func TestChainEquals(t *testing.T) {
 	})
 
 	t.Run("when two fields are not equal", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
-		mockT.EXPECT().Errorf(errorMessageFormat,
+		mockT := setupMockTWithCleanupCheck(t)
+		mockT.EXPECT().Fatalf(errorMessageFormat,
 			"Actual does not equal expected:\n - Name: John != Sam\n - Messages.slice[1].Body: Hello != Greetings",
 			Person{
 				Name:  "John",
@@ -313,8 +290,7 @@ func TestChainIsError(t *testing.T) {
 	const errorFormat = "\nActual error is not the expected error:\n\tActual:   %s\n\tExpected: %s"
 
 	t.Run("when equal error by reference", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 		mockT.EXPECT().Helper()
 
 		err := errors.New("my error")
@@ -324,8 +300,7 @@ func TestChainIsError(t *testing.T) {
 	})
 
 	t.Run("when equal error by Is method", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 		mockT.EXPECT().Helper()
 
 		const errMsg = "my error"
@@ -335,8 +310,7 @@ func TestChainIsError(t *testing.T) {
 	})
 
 	t.Run("when both are nil", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 		mockT.EXPECT().Helper()
 
 		ensure := ensure.New(mockT)
@@ -344,12 +318,11 @@ func TestChainIsError(t *testing.T) {
 	})
 
 	t.Run("when not error type", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 
 		err := errors.New("my error")
 		const val = "not an error"
-		mockT.EXPECT().Errorf("Got type %T, expected error: \"%v\"", val, err).After(
+		mockT.EXPECT().Fatalf("Got type %T, expected error: \"%v\"", val, err).After(
 			mockT.EXPECT().Helper(),
 		)
 
@@ -358,13 +331,12 @@ func TestChainIsError(t *testing.T) {
 	})
 
 	t.Run("when not equal: two different errors by reference", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 
 		err1 := errors.New("my error")
 		err2 := errors.New("my error")
 
-		mockT.EXPECT().Errorf(errorFormat, err1.Error(), err2.Error()).After(
+		mockT.EXPECT().Fatalf(errorFormat, err1.Error(), err2.Error()).After(
 			mockT.EXPECT().Helper(),
 		)
 
@@ -373,12 +345,11 @@ func TestChainIsError(t *testing.T) {
 	})
 
 	t.Run("when not equal: two different errors by Is method", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 
 		err1 := TestError{Message: "error message 1"}
 		err2 := TestError{Message: "error message 2"}
-		mockT.EXPECT().Errorf(errorFormat, err1.Error(), err2.Error()).After(
+		mockT.EXPECT().Fatalf(errorFormat, err1.Error(), err2.Error()).After(
 			mockT.EXPECT().Helper(),
 		)
 
@@ -387,11 +358,10 @@ func TestChainIsError(t *testing.T) {
 	})
 
 	t.Run("when not equal: expected nil", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 
 		err := errors.New("my error")
-		mockT.EXPECT().Errorf(errorFormat, err.Error(), "<nil>").After(
+		mockT.EXPECT().Fatalf(errorFormat, err.Error(), "<nil>").After(
 			mockT.EXPECT().Helper(),
 		)
 
@@ -400,11 +370,10 @@ func TestChainIsError(t *testing.T) {
 	})
 
 	t.Run("when not equal: got nil", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 
 		err := errors.New("my error")
-		mockT.EXPECT().Errorf(errorFormat, "<nil>", err.Error()).After(
+		mockT.EXPECT().Fatalf(errorFormat, "<nil>", err.Error()).After(
 			mockT.EXPECT().Helper(),
 		)
 
@@ -413,15 +382,14 @@ func TestChainIsError(t *testing.T) {
 	})
 
 	t.Run("when not equal: erk errors: different kinds", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 
 		type kind1 struct{ erk.DefaultKind }
 		type kind2 struct{ erk.DefaultKind }
 
 		expectedError := erk.New(kind1{}, "expected {{.a}}")
 		actualError := erk.NewWith(kind2{}, "actual {{.a}}", erk.Params{"a": "hi"})
-		mockT.EXPECT().Errorf(
+		mockT.EXPECT().Fatalf(
 			errorFormat,
 			fmt.Sprintf("{KIND: \"%s\", MESSAGE: \"actual hi\", PARAMS: map[a:hi]}", erk.GetKindString(actualError)),
 			fmt.Sprintf("{KIND: \"%s\", RAW MESSAGE: \"expected {{.a}}\", PARAMS: map[]}", erk.GetKindString(expectedError)),
@@ -434,14 +402,13 @@ func TestChainIsError(t *testing.T) {
 	})
 
 	t.Run("when not equal: erk errors: same kind", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 
 		type kind1 struct{ erk.DefaultKind }
 
 		expectedError := erk.New(kind1{}, "expected {{.a}}")
 		actualError := erk.NewWith(kind1{}, "actual {{.a}}", erk.Params{"a": "hi"})
-		mockT.EXPECT().Errorf(
+		mockT.EXPECT().Fatalf(
 			errorFormat,
 			fmt.Sprintf("{KIND: \"%s\", MESSAGE: \"actual hi\", PARAMS: map[a:hi]}", erk.GetKindString(actualError)),
 			fmt.Sprintf("{KIND: \"%s\", RAW MESSAGE: \"expected {{.a}}\", PARAMS: map[]}", erk.GetKindString(expectedError)),
@@ -454,14 +421,13 @@ func TestChainIsError(t *testing.T) {
 	})
 
 	t.Run("when not equal: erk errors: only expected is erk error", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 
 		type kind1 struct{ erk.DefaultKind }
 
 		expectedError := erk.New(kind1{}, "expected {{.a}}")
 		actualError := errors.New("actual")
-		mockT.EXPECT().Errorf(
+		mockT.EXPECT().Fatalf(
 			errorFormat,
 			actualError.Error(),
 			fmt.Sprintf("{KIND: \"%s\", RAW MESSAGE: \"expected {{.a}}\", PARAMS: map[]}", erk.GetKindString(expectedError)),
@@ -474,14 +440,13 @@ func TestChainIsError(t *testing.T) {
 	})
 
 	t.Run("when not equal: erk errors: only actual is erk error", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 
 		type kind1 struct{ erk.DefaultKind }
 
 		expectedError := errors.New("expected")
 		actualError := erk.NewWith(kind1{}, "actual {{.a}}", erk.Params{"a": "hi"})
-		mockT.EXPECT().Errorf(
+		mockT.EXPECT().Fatalf(
 			errorFormat,
 			fmt.Sprintf("{KIND: \"%s\", MESSAGE: \"actual hi\", PARAMS: map[a:hi]}", erk.GetKindString(actualError)),
 			expectedError.Error(),
@@ -496,8 +461,7 @@ func TestChainIsError(t *testing.T) {
 
 func TestChainIsNotError(t *testing.T) {
 	t.Run("when no error", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 		mockT.EXPECT().Helper().Times(2)
 
 		ensure := ensure.New(mockT)
@@ -505,11 +469,10 @@ func TestChainIsNotError(t *testing.T) {
 	})
 
 	t.Run("when error", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 
 		err := errors.New("my error")
-		mockT.EXPECT().Errorf("\nActual error is not the expected error:\n\tActual:   %s\n\tExpected: %s", err.Error(), "<nil>").After(
+		mockT.EXPECT().Fatalf("\nActual error is not the expected error:\n\tActual:   %s\n\tExpected: %s", err.Error(), "<nil>").After(
 			mockT.EXPECT().Helper().Times(2),
 		)
 
@@ -522,8 +485,7 @@ func TestChainIsEmpty(t *testing.T) {
 	const notEmptyFormat = "Got %+v with length %d, expected it to be empty"
 
 	t.Run("when empty: array", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 		mockT.EXPECT().Helper()
 
 		ensure := ensure.New(mockT)
@@ -531,10 +493,9 @@ func TestChainIsEmpty(t *testing.T) {
 	})
 
 	t.Run("when not empty: array", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 
-		mockT.EXPECT().Errorf(notEmptyFormat, [2]string{"1", "2"}, 2).After(
+		mockT.EXPECT().Fatalf(notEmptyFormat, [2]string{"1", "2"}, 2).After(
 			mockT.EXPECT().Helper(),
 		)
 
@@ -543,8 +504,7 @@ func TestChainIsEmpty(t *testing.T) {
 	})
 
 	t.Run("when empty: slice", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 		mockT.EXPECT().Helper()
 
 		ensure := ensure.New(mockT)
@@ -552,10 +512,9 @@ func TestChainIsEmpty(t *testing.T) {
 	})
 
 	t.Run("when not empty: slice", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 
-		mockT.EXPECT().Errorf(notEmptyFormat, []string{"1"}, 1).After(
+		mockT.EXPECT().Fatalf(notEmptyFormat, []string{"1"}, 1).After(
 			mockT.EXPECT().Helper(),
 		)
 
@@ -564,8 +523,7 @@ func TestChainIsEmpty(t *testing.T) {
 	})
 
 	t.Run("when empty: string", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 		mockT.EXPECT().Helper()
 
 		ensure := ensure.New(mockT)
@@ -573,10 +531,9 @@ func TestChainIsEmpty(t *testing.T) {
 	})
 
 	t.Run("when not empty: string", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 
-		mockT.EXPECT().Errorf(notEmptyFormat, "not empty", 9).After(
+		mockT.EXPECT().Fatalf(notEmptyFormat, "not empty", 9).After(
 			mockT.EXPECT().Helper(),
 		)
 
@@ -585,8 +542,7 @@ func TestChainIsEmpty(t *testing.T) {
 	})
 
 	t.Run("when empty: map", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 		mockT.EXPECT().Helper()
 
 		ensure := ensure.New(mockT)
@@ -594,10 +550,9 @@ func TestChainIsEmpty(t *testing.T) {
 	})
 
 	t.Run("when not empty: map", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 
-		mockT.EXPECT().Errorf(notEmptyFormat, map[string]string{"hello": "world"}, 1).After(
+		mockT.EXPECT().Fatalf(notEmptyFormat, map[string]string{"hello": "world"}, 1).After(
 			mockT.EXPECT().Helper(),
 		)
 
@@ -606,10 +561,9 @@ func TestChainIsEmpty(t *testing.T) {
 	})
 
 	t.Run("when not valid type", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockTWithCleanupCheck(t)
 
-		mockT.EXPECT().Errorf("Got type %T, expected array, slice, string, or map", 1234).After(
+		mockT.EXPECT().Fatalf("Got type %T, expected array, slice, string, or map", 1234).After(
 			mockT.EXPECT().Helper(),
 		)
 

--- a/ensurepkg/ensurepkg_test.go
+++ b/ensurepkg/ensurepkg_test.go
@@ -1,7 +1,6 @@
 package ensurepkg_test
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/JosiahWitt/ensure"
@@ -16,8 +15,7 @@ func TestGoVersion(t *testing.T) {
 
 func TestNew(t *testing.T) {
 	t.Run("when called through ensure.New", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
+		mockT := setupMockT(t)
 		ensure := ensure.New(mockT)
 
 		if ensure == nil {
@@ -26,41 +24,97 @@ func TestNew(t *testing.T) {
 	})
 
 	t.Run("when called directly", func(t *testing.T) {
-		defer func() {
-			rec := recover()
-			if rec == nil {
-				t.Error("expected panic, got none")
-				return
-			}
+		mockT := setupMockT(t)
 
-			if !strings.HasPrefix(rec.(string), "Do not call ensurepkg.New directly. Instead use ensure.New. Called ensurepkg.New from:") {
-				t.Error("incorrect panic message")
-			}
-		}()
+		gomock.InOrder(
+			mockT.EXPECT().Helper(),
+			mockT.EXPECT().Fatalf("Do not call `ensurepkg.InternalCreateDoNotCallDirectly(t)` directly. Instead use `ensure.New(t)`."),
+		)
 
-		ctrl := gomock.NewController(t)
-		mockT := mock_ensurepkg.NewMockT(ctrl)
 		ensurepkg.InternalCreateDoNotCallDirectly(mockT)
 	})
 }
 
-func TestEnsureFail(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	mockT := mock_ensurepkg.NewMockT(ctrl)
-	mockT.EXPECT().Fail().After(
+func TestEnsureFailf(t *testing.T) {
+	mockT := setupMockTWithCleanupCheck(t)
+
+	const message = "my message %s"
+	const arg1 = 123
+
+	mockT.EXPECT().Fatalf(message, arg1).After(
 		mockT.EXPECT().Helper(),
 	)
 
 	ensure := ensure.New(mockT)
-	ensure.Fail()
+	ensure.Failf(message, arg1)
 }
 
 func TestEnsureT(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	mockT := mock_ensurepkg.NewMockT(ctrl)
+	mockT := setupMockTWithCleanupCheck(t)
 
 	ensure := ensure.New(mockT)
 	if ensure.T() != mockT {
 		t.Error("T() does not equal mockT")
 	}
+}
+
+func TestEnsureCleanupCheck(t *testing.T) {
+	t.Run("when test was run", func(t *testing.T) {
+		mockT := setupMockT(t)
+
+		var cleanupFn func()
+		gomock.InOrder(
+			mockT.EXPECT().Helper(),
+			mockT.EXPECT().Cleanup(gomock.Any()).Do(func(fn func()) {
+				cleanupFn = fn
+			}),
+
+			mockT.EXPECT().Helper(), // For IsTrue call
+		)
+
+		ensure := ensure.New(mockT)
+		ensure(true).IsTrue()
+		cleanupFn()
+	})
+
+	t.Run("when test was not run", func(t *testing.T) {
+		mockT := setupMockT(t)
+
+		var cleanupFn func()
+		gomock.InOrder(
+			mockT.EXPECT().Helper(),
+			mockT.EXPECT().Cleanup(gomock.Any()).Do(func(fn func()) {
+				cleanupFn = fn
+			}),
+		)
+
+		ensure := ensure.New(mockT)
+		ensure(true)
+
+		gomock.InOrder(
+			mockT.EXPECT().Helper(),
+			mockT.EXPECT().Fatalf("Found ensure(<actual>) without chained assertion."),
+		)
+		cleanupFn()
+	})
+}
+
+func setupMockT(t *testing.T) *mock_ensurepkg.MockT {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	return mock_ensurepkg.NewMockT(ctrl)
+}
+
+func setupMockTWithCleanupCheck(t *testing.T) *mock_ensurepkg.MockT {
+	t.Helper()
+	mockT := setupMockT(t)
+
+	gomock.InOrder(
+		mockT.EXPECT().Helper(),
+		mockT.EXPECT().Cleanup(gomock.Any()).Do(func(fn func()) {
+			t.Cleanup(fn)
+		}),
+	)
+
+	return mockT
 }

--- a/ensurepkg/run.go
+++ b/ensurepkg/run.go
@@ -11,8 +11,10 @@ func (e Ensure) Run(name string, fn func(ensure Ensure)) {
 	c.run(name, fn)
 }
 
-func (c Chain) run(name string, fn func(ensure Ensure)) {
+func (c *Chain) run(name string, fn func(ensure Ensure)) {
 	c.t.Helper()
+	c.markRun()
+
 	c.t.Run(name, func(t *testing.T) {
 		ensure := wrap(t)
 		fn(ensure)

--- a/ensurepkg/run_table.go
+++ b/ensurepkg/run_table.go
@@ -59,7 +59,10 @@ type tableEntry struct {
 func (e Ensure) RunTableByIndex(table interface{}, fn func(ensure Ensure, i int)) {
 	entries, err := buildTable(table)
 	if err != nil {
-		panic(err.Error())
+		c := e(nil)
+		c.t.Helper()
+		c.markRun()
+		c.t.Fatalf(err.Error())
 	}
 
 	for i, entry := range entries {

--- a/ensurepkg/run_table_test.go
+++ b/ensurepkg/run_table_test.go
@@ -5,22 +5,19 @@ import (
 
 	"github.com/JosiahWitt/ensure"
 	"github.com/JosiahWitt/ensure/ensurepkg"
-	"github.com/JosiahWitt/ensure/internal/mocks/mock_ensurepkg"
 	"github.com/golang/mock/gomock"
 )
 
 func TestEnsureRunTableByIndex(t *testing.T) {
 	table := []struct {
 		Name                 string
-		ExpectedHelperCalls  int
 		ExpectedNames        []string
-		ExpectedPanicMessage string
+		ExpectedFatalMessage string
 		Table                interface{}
 	}{
 		{
-			Name:                "with valid table: slice",
-			ExpectedHelperCalls: 4,
-			ExpectedNames:       []string{"name 1", "name 2"},
+			Name:          "with valid table: slice",
+			ExpectedNames: []string{"name 1", "name 2", "name 3"},
 			Table: []struct {
 				Name  string
 				Value string
@@ -33,13 +30,16 @@ func TestEnsureRunTableByIndex(t *testing.T) {
 					Name:  "name 2",
 					Value: "item 2",
 				},
+				{
+					Name:  "name 3",
+					Value: "item 3",
+				},
 			},
 		},
 
 		{
-			Name:                "with valid table: array",
-			ExpectedHelperCalls: 4,
-			ExpectedNames:       []string{"name 1", "name 2"},
+			Name:          "with valid table: array",
+			ExpectedNames: []string{"name 1", "name 2"},
 			Table: [2]struct {
 				Name  string
 				Value string
@@ -57,13 +57,13 @@ func TestEnsureRunTableByIndex(t *testing.T) {
 
 		{
 			Name:                 "with invalid table type: not array or slice",
-			ExpectedPanicMessage: "Expected a slice or array for the table, got string",
+			ExpectedFatalMessage: "Expected a slice or array for the table, got string",
 			Table:                "my table",
 		},
 
 		{
 			Name:                 "with invalid table type: not array or slice of stucts",
-			ExpectedPanicMessage: "Expected entry in table to be a struct, got string",
+			ExpectedFatalMessage: "Expected entry in table to be a struct, got string",
 			Table: []string{
 				"item 1",
 				"item 2",
@@ -72,7 +72,7 @@ func TestEnsureRunTableByIndex(t *testing.T) {
 
 		{
 			Name:                 "with missing name",
-			ExpectedPanicMessage: "Name field does not exist on struct in table",
+			ExpectedFatalMessage: "Name field does not exist on struct in table",
 			Table: []struct {
 				Value string
 			}{
@@ -87,7 +87,7 @@ func TestEnsureRunTableByIndex(t *testing.T) {
 
 		{
 			Name:                 "with name with invalid type",
-			ExpectedPanicMessage: "Name field in struct in table is not a string",
+			ExpectedFatalMessage: "Name field in struct in table is not a string",
 			Table: []struct {
 				Name  int
 				Value string
@@ -105,7 +105,7 @@ func TestEnsureRunTableByIndex(t *testing.T) {
 
 		{
 			Name:                 "with missing name for one item",
-			ExpectedPanicMessage: "Errors encountered while building table:\n - table[1]: Name not set for item",
+			ExpectedFatalMessage: "Errors encountered while building table:\n - table[1]: Name not set for item",
 			Table: []struct {
 				Name  string
 				Value string
@@ -123,7 +123,7 @@ func TestEnsureRunTableByIndex(t *testing.T) {
 
 		{
 			Name:                 "with duplicate name",
-			ExpectedPanicMessage: "Errors encountered while building table:\n - table[2]: duplicate Name found; first occurrence was table[0].Name: name 1",
+			ExpectedFatalMessage: "Errors encountered while building table:\n - table[2]: duplicate Name found; first occurrence was table[0].Name: name 1",
 			Table: []struct {
 				Name  string
 				Value string
@@ -145,7 +145,7 @@ func TestEnsureRunTableByIndex(t *testing.T) {
 
 		{
 			Name:                 "with double duplicate name",
-			ExpectedPanicMessage: "Errors encountered while building table:\n - table[2]: duplicate Name found; first occurrence was table[0].Name: name 1\n - table[3]: duplicate Name found; first occurrence was table[0].Name: name 1",
+			ExpectedFatalMessage: "Errors encountered while building table:\n - table[2]: duplicate Name found; first occurrence was table[0].Name: name 1\n - table[3]: duplicate Name found; first occurrence was table[0].Name: name 1",
 			Table: []struct {
 				Name  string
 				Value string
@@ -174,14 +174,17 @@ func TestEnsureRunTableByIndex(t *testing.T) {
 		entry := entry // Pin range variable
 
 		t.Run(entry.Name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			mockT := mock_ensurepkg.NewMockT(ctrl)
-			mockT.EXPECT().Helper().Times(entry.ExpectedHelperCalls)
+			mockT := setupMockT(t)
+			expectedTableSize := len(entry.ExpectedNames)
+
+			mockT.EXPECT().Helper().Times(3 * expectedTableSize) // 3 = RunTableByIndex + run + before Cleanup call
+			mockT.EXPECT().Cleanup(gomock.Any()).Times(expectedTableSize)
 
 			// Build expected Run calls only if there's no expected error
 			expectedTestingInputs := []*testing.T{}
-			if entry.ExpectedPanicMessage == "" {
+			if entry.ExpectedFatalMessage == "" {
 				expectedRunCalls := []*gomock.Call{}
+
 				for _, name := range entry.ExpectedNames {
 					providedTestingInput := &testing.T{}
 					expectedTestingInputs = append(expectedTestingInputs, providedTestingInput)
@@ -197,12 +200,12 @@ func TestEnsureRunTableByIndex(t *testing.T) {
 				// Run calls should be in order
 				gomock.InOrder(expectedRunCalls...)
 			} else {
-				// Setup panic recovery
-				defer func() {
-					if msg := recover(); msg.(string) != entry.ExpectedPanicMessage {
-						t.Errorf("Expected panic message '%s', got: %v", entry.ExpectedPanicMessage, msg)
-					}
-				}()
+				gomock.InOrder(
+					mockT.EXPECT().Helper(),
+					mockT.EXPECT().Cleanup(gomock.Any()),
+					mockT.EXPECT().Helper(),
+					mockT.EXPECT().Fatalf(entry.ExpectedFatalMessage),
+				)
 			}
 
 			type Params struct {
@@ -217,24 +220,19 @@ func TestEnsureRunTableByIndex(t *testing.T) {
 				actualParams = append(actualParams, Params{ensure: ensure, i: i})
 			})
 
-			// This should not be reached on panic
-			if entry.ExpectedPanicMessage != "" {
-				t.Errorf("Expected panic, got none")
-			}
-
 			// Verify call count
-			if len(actualParams) != len(entry.ExpectedNames) {
-				t.Errorf("len(actualParams) != len(entry.ExpectedNames)")
+			if len(actualParams) != expectedTableSize {
+				t.Fatalf("len(actualParams) != expectedTableSize")
 			}
 
 			// Verify parameters are correct
 			for i, actualParam := range actualParams {
 				if actualParam.ensure.T() != expectedTestingInputs[i] {
-					t.Errorf("actualParams[%d].ensure.T() != expectedTestingInputs[%d]", i, i)
+					t.Fatalf("actualParams[%d].ensure.T() != expectedTestingInputs[%d]", i, i)
 				}
 
 				if actualParam.i != i {
-					t.Errorf("actualParams[%d].i != %d", i, i)
+					t.Fatalf("actualParams[%d].i != %d", i, i)
 				}
 			}
 		})

--- a/ensurepkg/run_test.go
+++ b/ensurepkg/run_test.go
@@ -5,13 +5,11 @@ import (
 
 	"github.com/JosiahWitt/ensure"
 	"github.com/JosiahWitt/ensure/ensurepkg"
-	"github.com/JosiahWitt/ensure/internal/mocks/mock_ensurepkg"
 	"github.com/golang/mock/gomock"
 )
 
 func TestEnsureRun(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	mockT := mock_ensurepkg.NewMockT(ctrl)
+	mockT := setupMockTWithCleanupCheck(t)
 	mockT.EXPECT().Helper().Times(2)
 
 	const name = "my test name"
@@ -29,6 +27,6 @@ func TestEnsureRun(t *testing.T) {
 	})
 
 	if actualParam == nil || actualParam.T() != providedTestingInput {
-		t.Errorf("Expected providedTestingInput to be wrapped by ensure")
+		t.Fatalf("Expected providedTestingInput to be wrapped by ensure")
 	}
 }

--- a/internal/mocks/mock_ensurepkg/mock_ensurepkg.go
+++ b/internal/mocks/mock_ensurepkg/mock_ensurepkg.go
@@ -33,23 +33,6 @@ func (m *MockT) EXPECT() *MockTMockRecorder {
 	return m.recorder
 }
 
-// Errorf mocks base method
-func (m *MockT) Errorf(format string, args ...interface{}) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{format}
-	for _, a := range args {
-		varargs = append(varargs, a)
-	}
-	m.ctrl.Call(m, "Errorf", varargs...)
-}
-
-// Errorf indicates an expected call of Errorf
-func (mr *MockTMockRecorder) Errorf(format interface{}, args ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{format}, args...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Errorf", reflect.TypeOf((*MockT)(nil).Errorf), varargs...)
-}
-
 // Fatalf mocks base method
 func (m *MockT) Fatalf(format string, args ...interface{}) {
 	m.ctrl.T.Helper()
@@ -81,18 +64,6 @@ func (mr *MockTMockRecorder) Run(name, f interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockT)(nil).Run), name, f)
 }
 
-// Fail mocks base method
-func (m *MockT) Fail() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Fail")
-}
-
-// Fail indicates an expected call of Fail
-func (mr *MockTMockRecorder) Fail() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Fail", reflect.TypeOf((*MockT)(nil).Fail))
-}
-
 // Helper mocks base method
 func (m *MockT) Helper() {
 	m.ctrl.T.Helper()
@@ -103,4 +74,16 @@ func (m *MockT) Helper() {
 func (mr *MockTMockRecorder) Helper() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Helper", reflect.TypeOf((*MockT)(nil).Helper))
+}
+
+// Cleanup mocks base method
+func (m *MockT) Cleanup(arg0 func()) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Cleanup", arg0)
+}
+
+// Cleanup indicates an expected call of Cleanup
+func (mr *MockTMockRecorder) Cleanup(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cleanup", reflect.TypeOf((*MockT)(nil).Cleanup), arg0)
 }


### PR DESCRIPTION
Closes #11 

Breaking changes:
- Requires Go 1.14+
- Removes `Fail()` method, and replaces it with `Failf(<msg>)`
- Everything now uses `Fatalf` instead of `Errorf`, so tests fail immediately if something goes wrong
- Fails tests if `ensure(...)` is called and is missing chained assertions. For example:

  ```go
  ensure(true) // Fails
  ```