### PR TITLE
Swap to calling Errorf instead of Fatalf from Cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.14, 1.15]
+        go-version: [1.14, 1.15, 1.16]
 
     steps:
       - name: Set up Go ${{ matrix.go-version }}
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.14, 1.15]
+        go-version: [1.14, 1.15, 1.16]
 
     steps:
       - name: Set up Go ${{ matrix.go-version }}
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.14, 1.15]
+        go-version: [1.14, 1.15, 1.16]
 
     steps:
       - name: Set up Go ${{ matrix.go-version }}

--- a/ensurepkg/ensurepkg.go
+++ b/ensurepkg/ensurepkg.go
@@ -99,6 +99,8 @@ func wrap(t T) Ensure {
 			memoized: memoized,
 		}
 
+		// Cleanup should never call Fatalf, otherwise panics are hidden, and
+		// the Fatal message is displayed instead, which is really tricky for debugging.
 		t.Helper()
 		t.Cleanup(func() {
 			if c.memoized.goMockController != nil {
@@ -107,7 +109,7 @@ func wrap(t T) Ensure {
 
 			if !c.wasRun {
 				t.Helper()
-				t.Fatalf("Found ensure(<actual>) without chained assertion.")
+				t.Errorf("Found ensure(<actual>) without chained assertion.")
 			}
 		})
 

--- a/ensurepkg/ensurepkg_test.go
+++ b/ensurepkg/ensurepkg_test.go
@@ -163,7 +163,7 @@ func TestEnsureCleanupCheck(t *testing.T) {
 
 		gomock.InOrder(
 			mockT.EXPECT().Helper(),
-			mockT.EXPECT().Fatalf("Found ensure(<actual>) without chained assertion."),
+			mockT.EXPECT().Errorf("Found ensure(<actual>) without chained assertion."),
 		)
 		cleanupFn()
 	})


### PR DESCRIPTION
Keeps panics that are raised after the chain is built from being silenced.

For example, this used to fail the test with only `Found ensure(<actual>) without chained assertion.`, when the error was actually a panic. Now the full panic will be shown.
```go
someSmallSlice := []string{"one item"}
ensure("hi").Equals(someSmallSlice[10000])
```