### PR TITLE
Cleanup unnecessary package path code

### DIFF
--- a/cmd/ensure/internal/ifacereader/scenarios/base/base.go
+++ b/cmd/ensure/internal/ifacereader/scenarios/base/base.go
@@ -5,5 +5,7 @@ import "github.com/JosiahWitt/ensure/cmd/ensure/internal/ifacereader"
 type ScenarioDetails struct {
 	Fixture interface{}
 
+	ExpectedPackagePaths []string
+
 	ExpectedMethods []*ifacereader.Method
 }

--- a/cmd/ensure/internal/ifacereader/scenarios/builtin/builtin.go
+++ b/cmd/ensure/internal/ifacereader/scenarios/builtin/builtin.go
@@ -21,47 +21,47 @@ var FixtureDetails = &base.ScenarioDetails{
 		{
 			Name: "Bool",
 			Inputs: []*ifacereader.Tuple{
-				{VariableName: "a", PackagePaths: []string{}, Type: "bool"},
+				{VariableName: "a", Type: "bool"},
 			},
 			Outputs: []*ifacereader.Tuple{
-				{VariableName: "", PackagePaths: []string{}, Type: "bool"},
+				{VariableName: "", Type: "bool"},
 			},
 		},
 		{
 			Name: "String",
 			Inputs: []*ifacereader.Tuple{
-				{VariableName: "a", PackagePaths: []string{}, Type: "string"},
+				{VariableName: "a", Type: "string"},
 			},
 			Outputs: []*ifacereader.Tuple{
-				{VariableName: "", PackagePaths: []string{}, Type: "string"},
+				{VariableName: "", Type: "string"},
 			},
 		},
 		{
 			Name: "Int",
 			Inputs: []*ifacereader.Tuple{
-				{VariableName: "a", PackagePaths: []string{}, Type: "int"},
+				{VariableName: "a", Type: "int"},
 			},
 			Outputs: []*ifacereader.Tuple{
-				{VariableName: "", PackagePaths: []string{}, Type: "int"},
+				{VariableName: "", Type: "int"},
 			},
 		},
 		{
 			Name: "Float64",
 			Inputs: []*ifacereader.Tuple{
-				{VariableName: "a", PackagePaths: []string{}, Type: "float64"},
+				{VariableName: "a", Type: "float64"},
 			},
 			Outputs: []*ifacereader.Tuple{
-				{VariableName: "", PackagePaths: []string{}, Type: "float64"},
+				{VariableName: "", Type: "float64"},
 			},
 		},
 
 		{
 			Name: "EmptyInterface",
 			Inputs: []*ifacereader.Tuple{
-				{VariableName: "a", PackagePaths: []string{}, Type: "interface{}"},
+				{VariableName: "a", Type: "interface{}"},
 			},
 			Outputs: []*ifacereader.Tuple{
-				{VariableName: "", PackagePaths: []string{}, Type: "interface{}"},
+				{VariableName: "", Type: "interface{}"},
 			},
 		},
 	},

--- a/cmd/ensure/internal/ifacereader/scenarios/complexexternaltypes/complexexternaltypes.go
+++ b/cmd/ensure/internal/ifacereader/scenarios/complexexternaltypes/complexexternaltypes.go
@@ -18,13 +18,14 @@ type Fixture interface {
 var FixtureDetails = &base.ScenarioDetails{
 	Fixture: (*Fixture)(nil),
 
+	ExpectedPackagePaths: []string{example1.PackagePath, example2.PackagePath},
+
 	ExpectedMethods: []*ifacereader.Method{
 		{
 			Name: "InterfaceWithNestedTypes",
 			Inputs: []*ifacereader.Tuple{
 				{
 					VariableName: "a",
-					PackagePaths: []string{example1.PackagePath, example2.PackagePath},
 					Type:         "interface{Method([]func(m *example1.Message) map[example1.String]*example2.User) *struct{ID []example2.Float64}}",
 				},
 			},
@@ -35,12 +36,10 @@ var FixtureDetails = &base.ScenarioDetails{
 			Inputs: []*ifacereader.Tuple{
 				{
 					VariableName: "a",
-					PackagePaths: []string{example1.PackagePath},
 					Type:         "[]func(m *example1.Message)",
 				},
 				{
 					VariableName: "b",
-					PackagePaths: []string{example1.PackagePath, example2.PackagePath},
 					Type:         "[][]map[example1.String]*example2.User",
 					Variadic:     true,
 				},
@@ -48,17 +47,14 @@ var FixtureDetails = &base.ScenarioDetails{
 			Outputs: []*ifacereader.Tuple{
 				{
 					VariableName: "x",
-					PackagePaths: []string{},
 					Type:         "string",
 				},
 				{
 					VariableName: "y",
-					PackagePaths: []string{example2.PackagePath},
 					Type:         "[]*struct{ID example2.Float64}",
 				},
 				{
 					VariableName: "z",
-					PackagePaths: []string{},
 					Type:         "error",
 				},
 			},

--- a/cmd/ensure/internal/ifacereader/scenarios/externaltypes/externaltypes.go
+++ b/cmd/ensure/internal/ifacereader/scenarios/externaltypes/externaltypes.go
@@ -17,11 +17,13 @@ type Fixture interface {
 var FixtureDetails = &base.ScenarioDetails{
 	Fixture: (*Fixture)(nil),
 
+	ExpectedPackagePaths: []string{example1.PackagePath, example2.PackagePath},
+
 	ExpectedMethods: []*ifacereader.Method{
 		{
 			Name: "ExternalInput",
 			Inputs: []*ifacereader.Tuple{
-				{VariableName: "a", PackagePaths: []string{example1.PackagePath}, Type: "*example1.Message"},
+				{VariableName: "a", Type: "*example1.Message"},
 			},
 			Outputs: []*ifacereader.Tuple{},
 		},
@@ -29,25 +31,25 @@ var FixtureDetails = &base.ScenarioDetails{
 			Name:   "ExternalOutput",
 			Inputs: []*ifacereader.Tuple{},
 			Outputs: []*ifacereader.Tuple{
-				{VariableName: "", PackagePaths: []string{example1.PackagePath}, Type: "*example1.Message"},
+				{VariableName: "", Type: "*example1.Message"},
 			},
 		},
 		{
 			Name: "ExternalIO",
 			Inputs: []*ifacereader.Tuple{
-				{VariableName: "a", PackagePaths: []string{example1.PackagePath}, Type: "*example1.Message"},
+				{VariableName: "a", Type: "*example1.Message"},
 			},
 			Outputs: []*ifacereader.Tuple{
-				{VariableName: "", PackagePaths: []string{example1.PackagePath}, Type: "*example1.Message"},
+				{VariableName: "", Type: "*example1.Message"},
 			},
 		},
 		{
 			Name: "ExternalIODifferentPackages",
 			Inputs: []*ifacereader.Tuple{
-				{VariableName: "a", PackagePaths: []string{example1.PackagePath}, Type: "*example1.Message"},
+				{VariableName: "a", Type: "*example1.Message"},
 			},
 			Outputs: []*ifacereader.Tuple{
-				{VariableName: "", PackagePaths: []string{example2.PackagePath}, Type: "*example2.User"},
+				{VariableName: "", Type: "*example2.User"},
 			},
 		},
 	},

--- a/cmd/ensure/internal/ifacereader/scenarios/inlineexternaltypes/inlineexternaltypes.go
+++ b/cmd/ensure/internal/ifacereader/scenarios/inlineexternaltypes/inlineexternaltypes.go
@@ -47,79 +47,81 @@ type Fixture interface {
 var FixtureDetails = &base.ScenarioDetails{
 	Fixture: (*Fixture)(nil),
 
+	ExpectedPackagePaths: []string{example1.PackagePath, example2.PackagePath},
+
 	ExpectedMethods: []*ifacereader.Method{
 		{
 			Name: "ExternalIOFuncWithInputs",
 			Inputs: []*ifacereader.Tuple{
-				{VariableName: "a", PackagePaths: []string{example1.PackagePath}, Type: "func(m *example1.Message)"},
+				{VariableName: "a", Type: "func(m *example1.Message)"},
 			},
 			Outputs: []*ifacereader.Tuple{
-				{VariableName: "", PackagePaths: []string{example2.PackagePath}, Type: "func(u *example2.User)"},
+				{VariableName: "", Type: "func(u *example2.User)"},
 			},
 		},
 		{
 			Name: "ExternalIOFuncWithOutputs",
 			Inputs: []*ifacereader.Tuple{
-				{VariableName: "a", PackagePaths: []string{example1.PackagePath}, Type: "func() *example1.Message"},
+				{VariableName: "a", Type: "func() *example1.Message"},
 			},
 			Outputs: []*ifacereader.Tuple{
-				{VariableName: "", PackagePaths: []string{example2.PackagePath}, Type: "func() *example2.User"},
+				{VariableName: "", Type: "func() *example2.User"},
 			},
 		},
 		{
 			Name: "ExternalIOFuncWithIO",
 			Inputs: []*ifacereader.Tuple{
-				{VariableName: "a", PackagePaths: []string{example1.PackagePath, example2.PackagePath}, Type: "func(m *example1.Message) *example2.User"},
+				{VariableName: "a", Type: "func(m *example1.Message) *example2.User"},
 			},
 			Outputs: []*ifacereader.Tuple{
-				{VariableName: "", PackagePaths: []string{example2.PackagePath, example1.PackagePath}, Type: "func(f example2.Float64) example1.String"},
+				{VariableName: "", Type: "func(f example2.Float64) example1.String"},
 			},
 		},
 		{
 			Name: "ExternalIOFuncWithIOSamePackage",
 			Inputs: []*ifacereader.Tuple{
-				{VariableName: "a", PackagePaths: []string{example1.PackagePath}, Type: "func(m *example1.Message) example1.String"},
+				{VariableName: "a", Type: "func(m *example1.Message) example1.String"},
 			},
 			Outputs: []*ifacereader.Tuple{
-				{VariableName: "", PackagePaths: []string{example2.PackagePath}, Type: "func(u *example2.User) example2.Float64"},
+				{VariableName: "", Type: "func(u *example2.User) example2.Float64"},
 			},
 		},
 
 		{
 			Name: "ExternalIOStruct",
 			Inputs: []*ifacereader.Tuple{
-				{VariableName: "a", PackagePaths: []string{example1.PackagePath}, Type: "*struct{m *example1.Message}"},
+				{VariableName: "a", Type: "*struct{m *example1.Message}"},
 			},
 			Outputs: []*ifacereader.Tuple{
-				{VariableName: "", PackagePaths: []string{example2.PackagePath}, Type: "*struct{m *example2.User}"},
+				{VariableName: "", Type: "*struct{m *example2.User}"},
 			},
 		},
 		{
 			Name: "ExternalIOStructWithMultiplePackages",
 			Inputs: []*ifacereader.Tuple{
-				{VariableName: "a", PackagePaths: []string{example1.PackagePath, example2.PackagePath}, Type: "*struct{m *example1.Message; f example2.Float64}"},
+				{VariableName: "a", Type: "*struct{m *example1.Message; f example2.Float64}"},
 			},
 			Outputs: []*ifacereader.Tuple{
-				{VariableName: "", PackagePaths: []string{example2.PackagePath, example1.PackagePath}, Type: "*struct{m *example2.User; s example1.String}"},
+				{VariableName: "", Type: "*struct{m *example2.User; s example1.String}"},
 			},
 		},
 		{
 			Name: "ExternalIOStructWithSamePackage",
 			Inputs: []*ifacereader.Tuple{
-				{VariableName: "a", PackagePaths: []string{example1.PackagePath}, Type: "*struct{m *example1.Message; s example1.String}"},
+				{VariableName: "a", Type: "*struct{m *example1.Message; s example1.String}"},
 			},
 			Outputs: []*ifacereader.Tuple{
-				{VariableName: "", PackagePaths: []string{example2.PackagePath}, Type: "*struct{m *example2.User; f example2.Float64}"},
+				{VariableName: "", Type: "*struct{m *example2.User; f example2.Float64}"},
 			},
 		},
 
 		{
 			Name: "ExternalIOInterface",
 			Inputs: []*ifacereader.Tuple{
-				{VariableName: "a", PackagePaths: []string{example1.PackagePath}, Type: "interface{Input(m *example1.Message)}"},
+				{VariableName: "a", Type: "interface{Input(m *example1.Message)}"},
 			},
 			Outputs: []*ifacereader.Tuple{
-				{VariableName: "", PackagePaths: []string{example2.PackagePath}, Type: "interface{Output() *example2.User}"},
+				{VariableName: "", Type: "interface{Output() *example2.User}"},
 			},
 		},
 		{
@@ -127,14 +129,12 @@ var FixtureDetails = &base.ScenarioDetails{
 			Inputs: []*ifacereader.Tuple{
 				{
 					VariableName: "a",
-					PackagePaths: []string{example1.PackagePath, example2.PackagePath},
 					Type:         "interface{Method1(m *example1.Message) example2.Float64; Method2(u *example2.User) example1.String}",
 				},
 			},
 			Outputs: []*ifacereader.Tuple{
 				{
 					VariableName: "",
-					PackagePaths: []string{example2.PackagePath, example1.PackagePath},
 					Type:         "interface{Method1(f example2.Float64) *example1.Message; Method2(s example1.String) *example2.User}",
 				},
 			},
@@ -144,14 +144,12 @@ var FixtureDetails = &base.ScenarioDetails{
 			Inputs: []*ifacereader.Tuple{
 				{
 					VariableName: "a",
-					PackagePaths: []string{example1.PackagePath},
 					Type:         "interface{IO(m *example1.Message) example1.String}",
 				},
 			},
 			Outputs: []*ifacereader.Tuple{
 				{
 					VariableName: "",
-					PackagePaths: []string{example2.PackagePath},
 					Type:         "interface{IO(f example2.Float64) *example2.User}",
 				},
 			},

--- a/cmd/ensure/internal/ifacereader/scenarios/iterableexternaltypes/iterableexternaltypes.go
+++ b/cmd/ensure/internal/ifacereader/scenarios/iterableexternaltypes/iterableexternaltypes.go
@@ -22,70 +22,72 @@ type Fixture interface {
 var FixtureDetails = &base.ScenarioDetails{
 	Fixture: (*Fixture)(nil),
 
+	ExpectedPackagePaths: []string{example1.PackagePath, example2.PackagePath},
+
 	ExpectedMethods: []*ifacereader.Method{
 		{
 			Name: "ExternalIOSlice",
 			Inputs: []*ifacereader.Tuple{
-				{VariableName: "a", PackagePaths: []string{example1.PackagePath}, Type: "[]*example1.Message"},
+				{VariableName: "a", Type: "[]*example1.Message"},
 			},
 			Outputs: []*ifacereader.Tuple{
-				{VariableName: "", PackagePaths: []string{example2.PackagePath}, Type: "[]*example2.User"},
+				{VariableName: "", Type: "[]*example2.User"},
 			},
 		},
 		{
 			Name: "ExternalIOArray",
 			Inputs: []*ifacereader.Tuple{
-				{VariableName: "a", PackagePaths: []string{example1.PackagePath}, Type: "[2]*example1.Message"},
+				{VariableName: "a", Type: "[2]*example1.Message"},
 			},
 			Outputs: []*ifacereader.Tuple{
-				{VariableName: "", PackagePaths: []string{example2.PackagePath}, Type: "[3]*example2.User"},
+				{VariableName: "", Type: "[3]*example2.User"},
 			},
 		},
 
 		{
 			Name: "ExternalIOMapValue",
 			Inputs: []*ifacereader.Tuple{
-				{VariableName: "a", PackagePaths: []string{example1.PackagePath}, Type: "map[string]*example1.Message"},
+				{VariableName: "a", Type: "map[string]*example1.Message"},
 			},
 			Outputs: []*ifacereader.Tuple{
-				{VariableName: "", PackagePaths: []string{example2.PackagePath}, Type: "map[int]*example2.User"},
+				{VariableName: "", Type: "map[int]*example2.User"},
 			},
 		},
 		{
 			Name: "ExternalIOMapKey",
 			Inputs: []*ifacereader.Tuple{
-				{VariableName: "a", PackagePaths: []string{example2.PackagePath}, Type: "map[example2.Float64]string"},
+				{VariableName: "a", Type: "map[example2.Float64]string"},
 			},
 			Outputs: []*ifacereader.Tuple{
-				{VariableName: "", PackagePaths: []string{example1.PackagePath}, Type: "map[example1.String]string"},
+				{VariableName: "", Type: "map[example1.String]string"},
 			},
 		},
 		{
 			Name: "ExternalIOMapKeyAndValue",
 			Inputs: []*ifacereader.Tuple{
-				{VariableName: "a", PackagePaths: []string{example2.PackagePath, example1.PackagePath}, Type: "map[example2.Float64]*example1.Message"},
+				{VariableName: "a", Type: "map[example2.Float64]*example1.Message"},
 			},
 			Outputs: []*ifacereader.Tuple{
-				{VariableName: "", PackagePaths: []string{example1.PackagePath, example2.PackagePath}, Type: "map[example1.String]*example2.User"},
+				{VariableName: "", Type: "map[example1.String]*example2.User"},
 			},
 		},
 		{
 			Name: "ExternalIOMapKeyAndValueSamePackage",
 			Inputs: []*ifacereader.Tuple{
-				{VariableName: "a", PackagePaths: []string{example1.PackagePath}, Type: "map[example1.String]*example1.Message"},
+				{VariableName: "a", Type: "map[example1.String]*example1.Message"},
 			},
 			Outputs: []*ifacereader.Tuple{
-				{VariableName: "", PackagePaths: []string{example2.PackagePath}, Type: "map[example2.Float64]*example2.User"},
+				{VariableName: "", Type: "map[example2.Float64]*example2.User"},
 			},
 		},
 
 		{
 			Name: "ExternalIOChan",
 			Inputs: []*ifacereader.Tuple{
-				{VariableName: "a", PackagePaths: []string{example1.PackagePath}, Type: "chan *example1.Message"},
+				{VariableName: "a", Type: "chan *example1.Message"},
 			},
 			Outputs: []*ifacereader.Tuple{
-				{VariableName: "", PackagePaths: []string{example2.PackagePath}, Type: "chan *example2.User"},
+				{VariableName: "", Type: "chan *example2.User"},
 			},
 		},
 	},

--- a/cmd/ensure/internal/ifacereader/scenarios/variadic/variadic.go
+++ b/cmd/ensure/internal/ifacereader/scenarios/variadic/variadic.go
@@ -16,11 +16,11 @@ var FixtureDetails = &base.ScenarioDetails{
 		{
 			Name: "Transform",
 			Inputs: []*ifacereader.Tuple{
-				{VariableName: "prefix", PackagePaths: []string{}, Type: "string"},
-				{VariableName: "strs", PackagePaths: []string{}, Type: "[]string", Variadic: true},
+				{VariableName: "prefix", Type: "string"},
+				{VariableName: "strs", Type: "[]string", Variadic: true},
 			},
 			Outputs: []*ifacereader.Tuple{
-				{VariableName: "", PackagePaths: []string{}, Type: "[]string"},
+				{VariableName: "", Type: "[]string"},
 			},
 		},
 	},

--- a/cmd/ensure/internal/mockgen/scenarios/multiple_interfaces/fixture.go
+++ b/cmd/ensure/internal/mockgen/scenarios/multiple_interfaces/fixture.go
@@ -12,12 +12,12 @@ var Package = &ifacereader.Package{
 				{
 					Name: "TransformString",
 					Inputs: []*ifacereader.Tuple{
-						{VariableName: "prefix", PackagePaths: []string{}, Type: "string"},
-						{VariableName: "str", PackagePaths: []string{}, Type: "string"},
+						{VariableName: "prefix", Type: "string"},
+						{VariableName: "str", Type: "string"},
 					},
 					Outputs: []*ifacereader.Tuple{
-						{VariableName: "", PackagePaths: []string{}, Type: "string"},
-						{VariableName: "", PackagePaths: []string{}, Type: "error"},
+						{VariableName: "", Type: "string"},
+						{VariableName: "", Type: "error"},
 					},
 				},
 			},
@@ -28,19 +28,19 @@ var Package = &ifacereader.Package{
 				{
 					Name: "TransformInt",
 					Inputs: []*ifacereader.Tuple{
-						{VariableName: "i", PackagePaths: []string{}, Type: "int"},
+						{VariableName: "i", Type: "int"},
 					},
 					Outputs: []*ifacereader.Tuple{
-						{VariableName: "", PackagePaths: []string{}, Type: "int"},
+						{VariableName: "", Type: "int"},
 					},
 				},
 				{
 					Name: "TransformFloat64",
 					Inputs: []*ifacereader.Tuple{
-						{VariableName: "f", PackagePaths: []string{}, Type: "float64"},
+						{VariableName: "f", Type: "float64"},
 					},
 					Outputs: []*ifacereader.Tuple{
-						{VariableName: "", PackagePaths: []string{}, Type: "float64"},
+						{VariableName: "", Type: "float64"},
 					},
 				},
 			},

--- a/cmd/ensure/internal/mockgen/scenarios/single_interface_multiple_methods/fixture.go
+++ b/cmd/ensure/internal/mockgen/scenarios/single_interface_multiple_methods/fixture.go
@@ -12,21 +12,21 @@ var Package = &ifacereader.Package{
 				{
 					Name: "TransformString",
 					Inputs: []*ifacereader.Tuple{
-						{VariableName: "prefix", PackagePaths: []string{}, Type: "string"},
-						{VariableName: "str", PackagePaths: []string{}, Type: "string"},
+						{VariableName: "prefix", Type: "string"},
+						{VariableName: "str", Type: "string"},
 					},
 					Outputs: []*ifacereader.Tuple{
-						{VariableName: "", PackagePaths: []string{}, Type: "string"},
-						{VariableName: "", PackagePaths: []string{}, Type: "error"},
+						{VariableName: "", Type: "string"},
+						{VariableName: "", Type: "error"},
 					},
 				},
 				{
 					Name: "TransformFloat64",
 					Inputs: []*ifacereader.Tuple{
-						{VariableName: "f", PackagePaths: []string{}, Type: "float64"},
+						{VariableName: "f", Type: "float64"},
 					},
 					Outputs: []*ifacereader.Tuple{
-						{VariableName: "", PackagePaths: []string{}, Type: "float64"},
+						{VariableName: "", Type: "float64"},
 					},
 				},
 			},

--- a/cmd/ensure/internal/mockgen/scenarios/single_method_external_imports/fixture.go
+++ b/cmd/ensure/internal/mockgen/scenarios/single_method_external_imports/fixture.go
@@ -15,11 +15,11 @@ var Package = &ifacereader.Package{
 				{
 					Name: "Transform",
 					Inputs: []*ifacereader.Tuple{
-						{VariableName: "user", PackagePaths: []string{}, Type: "*external1.User"},
-						{VariableName: "message", PackagePaths: []string{}, Type: "*external2.Message"},
+						{VariableName: "user", Type: "*external1.User"},
+						{VariableName: "message", Type: "*external2.Message"},
 					},
 					Outputs: []*ifacereader.Tuple{
-						{VariableName: "", PackagePaths: []string{}, Type: "external1.String"},
+						{VariableName: "", Type: "external1.String"},
 					},
 				},
 			},

--- a/cmd/ensure/internal/mockgen/scenarios/single_method_external_imports_clash_with_required/fixture.go
+++ b/cmd/ensure/internal/mockgen/scenarios/single_method_external_imports_clash_with_required/fixture.go
@@ -15,8 +15,8 @@ var Package = &ifacereader.Package{
 				{
 					Name: "Do",
 					Inputs: []*ifacereader.Tuple{
-						{VariableName: "thing", PackagePaths: []string{}, Type: "*reflect.Thing"},
-						{VariableName: "other", PackagePaths: []string{}, Type: "*gomock.Other"},
+						{VariableName: "thing", Type: "*reflect.Thing"},
+						{VariableName: "other", Type: "*gomock.Other"},
 					},
 					Outputs: []*ifacereader.Tuple{},
 				},

--- a/cmd/ensure/internal/mockgen/scenarios/single_method_external_imports_with_aliases/fixture.go
+++ b/cmd/ensure/internal/mockgen/scenarios/single_method_external_imports_with_aliases/fixture.go
@@ -15,11 +15,11 @@ var Package = &ifacereader.Package{
 				{
 					Name: "Transform",
 					Inputs: []*ifacereader.Tuple{
-						{VariableName: "user", PackagePaths: []string{}, Type: "*models.User"},
-						{VariableName: "message", PackagePaths: []string{}, Type: "*models2.Message"},
+						{VariableName: "user", Type: "*models.User"},
+						{VariableName: "message", Type: "*models2.Message"},
 					},
 					Outputs: []*ifacereader.Tuple{
-						{VariableName: "", PackagePaths: []string{}, Type: "models.String"},
+						{VariableName: "", Type: "models.String"},
 					},
 				},
 			},

--- a/cmd/ensure/internal/mockgen/scenarios/single_method_multiple_params/fixture.go
+++ b/cmd/ensure/internal/mockgen/scenarios/single_method_multiple_params/fixture.go
@@ -12,12 +12,12 @@ var Package = &ifacereader.Package{
 				{
 					Name: "TransformString",
 					Inputs: []*ifacereader.Tuple{
-						{VariableName: "prefix", PackagePaths: []string{}, Type: "string"},
-						{VariableName: "str", PackagePaths: []string{}, Type: "string"},
+						{VariableName: "prefix", Type: "string"},
+						{VariableName: "str", Type: "string"},
 					},
 					Outputs: []*ifacereader.Tuple{
-						{VariableName: "", PackagePaths: []string{}, Type: "string"},
-						{VariableName: "", PackagePaths: []string{}, Type: "error"},
+						{VariableName: "", Type: "string"},
+						{VariableName: "", Type: "error"},
 					},
 				},
 			},

--- a/cmd/ensure/internal/mockgen/scenarios/single_method_named_outputs/fixture.go
+++ b/cmd/ensure/internal/mockgen/scenarios/single_method_named_outputs/fixture.go
@@ -12,12 +12,12 @@ var Package = &ifacereader.Package{
 				{
 					Name: "TransformString",
 					Inputs: []*ifacereader.Tuple{
-						{VariableName: "prefix", PackagePaths: []string{}, Type: "string"},
-						{VariableName: "str", PackagePaths: []string{}, Type: "string"},
+						{VariableName: "prefix", Type: "string"},
+						{VariableName: "str", Type: "string"},
 					},
 					Outputs: []*ifacereader.Tuple{
-						{VariableName: "transformedStr", PackagePaths: []string{}, Type: "string"},
-						{VariableName: "err", PackagePaths: []string{}, Type: "error"},
+						{VariableName: "transformedStr", Type: "string"},
+						{VariableName: "err", Type: "error"},
 					},
 				},
 			},

--- a/cmd/ensure/internal/mockgen/scenarios/single_method_no_imports/fixture.go
+++ b/cmd/ensure/internal/mockgen/scenarios/single_method_no_imports/fixture.go
@@ -12,10 +12,10 @@ var Package = &ifacereader.Package{
 				{
 					Name: "TransformString",
 					Inputs: []*ifacereader.Tuple{
-						{VariableName: "str", PackagePaths: []string{}, Type: "string"},
+						{VariableName: "str", Type: "string"},
 					},
 					Outputs: []*ifacereader.Tuple{
-						{VariableName: "", PackagePaths: []string{}, Type: "string"},
+						{VariableName: "", Type: "string"},
 					},
 				},
 			},

--- a/cmd/ensure/internal/mockgen/scenarios/single_method_unnamed_inputs/fixture.go
+++ b/cmd/ensure/internal/mockgen/scenarios/single_method_unnamed_inputs/fixture.go
@@ -12,12 +12,12 @@ var Package = &ifacereader.Package{
 				{
 					Name: "TransformString",
 					Inputs: []*ifacereader.Tuple{
-						{VariableName: "", PackagePaths: []string{}, Type: "string"},
-						{VariableName: "", PackagePaths: []string{}, Type: "string"},
+						{VariableName: "", Type: "string"},
+						{VariableName: "", Type: "string"},
 					},
 					Outputs: []*ifacereader.Tuple{
-						{VariableName: "", PackagePaths: []string{}, Type: "string"},
-						{VariableName: "", PackagePaths: []string{}, Type: "error"},
+						{VariableName: "", Type: "string"},
+						{VariableName: "", Type: "error"},
 					},
 				},
 			},

--- a/cmd/ensure/internal/mockgen/scenarios/single_method_variadic_input/fixture.go
+++ b/cmd/ensure/internal/mockgen/scenarios/single_method_variadic_input/fixture.go
@@ -12,12 +12,12 @@ var Package = &ifacereader.Package{
 				{
 					Name: "TransformString",
 					Inputs: []*ifacereader.Tuple{
-						{VariableName: "prefix", PackagePaths: []string{}, Type: "string"},
-						{VariableName: "strs", PackagePaths: []string{}, Type: "[]string", Variadic: true},
+						{VariableName: "prefix", Type: "string"},
+						{VariableName: "strs", Type: "[]string", Variadic: true},
 					},
 					Outputs: []*ifacereader.Tuple{
-						{VariableName: "", PackagePaths: []string{}, Type: "string"},
-						{VariableName: "", PackagePaths: []string{}, Type: "error"},
+						{VariableName: "", Type: "string"},
+						{VariableName: "", Type: "error"},
 					},
 				},
 			},


### PR DESCRIPTION
Since we use the `types.TypeString` function, we actually get all the package paths we need by that single method call, since it recursively calls our callback. Thus, the custom code to recurse through the types is unused and can be removed.