### PR TITLE
Support Go 1.19 Doc Format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,13 +58,13 @@ jobs:
       - name: Lint Ensure Package
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.45.2
+          version: v1.49.0
           skip-go-installation: true
 
       - name: Lint Ensure CLI
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.45.2
+          version: v1.49.0
           skip-go-installation: true
           working-directory: cmd/ensure
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,12 @@
 name: CI
 on: [push]
 jobs:
-
   test:
     name: Test
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.16, 1.17, 1.18]
+        go-version: [1.16, 1.17, 1.18, 1.19]
 
     steps:
       - name: Set up Go ${{ matrix.go-version }}
@@ -38,13 +37,12 @@ jobs:
           files: cli-coverage.txt
           flags: cli
 
-
   lint:
     name: Lint
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.16, 1.17, 1.18]
+        go-version: [1.16, 1.17, 1.18, 1.19]
 
     steps:
       - name: Set up Go ${{ matrix.go-version }}
@@ -68,13 +66,12 @@ jobs:
           skip-go-installation: true
           working-directory: cmd/ensure
 
-
   regression-test:
     name: Regression Test
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.16, 1.17, 1.18]
+        go-version: [1.16, 1.17, 1.18, 1.19]
 
     steps:
       - name: Set up Go ${{ matrix.go-version }}
@@ -90,6 +87,12 @@ jobs:
 
       - name: Generate CLI Mocks
         run: (cd cmd/ensure; make generate-mocks)
+
+      - name: Run go fmt for package
+        run: go fmt ./...
+
+      - name: Run go fmt for CLI
+        run: (cd cmd/ensure; go fmt ./...)
 
       - name: Git diff
         run: git diff

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,14 @@ linters:
     - interfacer
     - scopelint
     - varnamelen
+    - exhaustruct
+    # Deprecated:
+    - nosnakecase
+    - deadcode
+    - ifshort
+    - structcheck
+    - varcheck
+    - exhaustivestruct
 
 linters-settings:
   lll:
@@ -28,15 +36,9 @@ issues:
         - goerr113
         - dupl
         - paralleltest
-        - exhaustivestruct
         - gocognit
         - cyclop
         - forcetypeassert
         - ifshort
         - thelper
         - maintidx
-
-    # erk types don't need to be exhaustive
-    - text: ".*in erk.*"
-      linters:
-        - exhaustivestruct

--- a/cmd/ensure/.golangci.yml
+++ b/cmd/ensure/.golangci.yml
@@ -12,8 +12,15 @@ linters:
     - interfacer
     - scopelint
     - varnamelen
-    - exhaustivestruct
     - gofumpt
+    - exhaustruct
+    # Deprecated:
+    - nosnakecase
+    - deadcode
+    - ifshort
+    - structcheck
+    - varcheck
+    - exhaustivestruct
 
 linters-settings:
   lll:
@@ -48,8 +55,3 @@ issues:
       linters:
         - revive
         - stylecheck
-
-    # erk types don't need to be exhaustive
-    - text: ".*in erk.*"
-      linters:
-        - exhaustivestruct

--- a/cmd/ensure/internal/cmd/mocks_test.go
+++ b/cmd/ensure/internal/cmd/mocks_test.go
@@ -2,7 +2,7 @@ package cmd_test
 
 import (
 	"errors"
-	"io/ioutil"
+	"io"
 	"log"
 	"testing"
 
@@ -187,7 +187,7 @@ func TestMocksGenerate(t *testing.T) {
 	ensure.RunTableByIndex(table, func(ensure ensurepkg.Ensure, i int) {
 		entry := table[i]
 		entry.Subject.Getwd = entry.Getwd
-		entry.Subject.Logger = log.New(ioutil.Discard, "", 0)
+		entry.Subject.Logger = log.New(io.Discard, "", 0)
 
 		err := entry.Subject.Run(append([]string{"ensure", "mocks", "generate"}, entry.Flags...))
 		ensure(err).IsError(entry.ExpectedError)
@@ -285,7 +285,7 @@ func TestMocksTidy(t *testing.T) {
 	ensure.RunTableByIndex(table, func(ensure ensurepkg.Ensure, i int) {
 		entry := table[i]
 		entry.Subject.Getwd = entry.Getwd
-		entry.Subject.Logger = log.New(ioutil.Discard, "", 0)
+		entry.Subject.Logger = log.New(io.Discard, "", 0)
 
 		err := entry.Subject.Run([]string{"ensure", "mocks", "tidy"})
 		ensure(err).IsError(entry.ExpectedError)

--- a/cmd/ensure/internal/fswrite/fswrite.go
+++ b/cmd/ensure/internal/fswrite/fswrite.go
@@ -2,7 +2,6 @@
 package fswrite
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -20,9 +19,9 @@ type FSWrite struct{}
 
 var _ Writable = &FSWrite{}
 
-// WriteFile wraps ioutil.WriteFile.
+// WriteFile wraps os.WriteFile.
 func (*FSWrite) WriteFile(filename string, data string, perm os.FileMode) error {
-	return ioutil.WriteFile(filename, []byte(data), perm)
+	return os.WriteFile(filename, []byte(data), perm)
 }
 
 // MkdirAll wraps os.MkdirAll.

--- a/cmd/ensure/internal/fswrite/fswrite_test.go
+++ b/cmd/ensure/internal/fswrite/fswrite_test.go
@@ -1,7 +1,6 @@
 package fswrite_test
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -21,7 +20,7 @@ func TestWriteFile(t *testing.T) {
 	err := fsWrite.WriteFile(fileName, contents, 0655)
 	ensure(err).IsNotError()
 
-	actualContents, err := ioutil.ReadFile(fileName)
+	actualContents, err := os.ReadFile(fileName)
 	ensure(err).IsNotError()
 	ensure(string(actualContents)).Equals(contents)
 }
@@ -35,7 +34,7 @@ func TestMkdirAll(t *testing.T) {
 	ensure(err).IsNotError()
 
 	// Ensure we can write to the directory
-	err = ioutil.WriteFile(filepath.Join(dirName, "file.txt"), []byte("testing"), 0600)
+	err = os.WriteFile(filepath.Join(dirName, "file.txt"), []byte("testing"), 0600)
 	ensure(err).IsNotError()
 }
 

--- a/cmd/ensure/internal/mockgen/scenarios/generics_multiple_type_params/pkg1.expected
+++ b/cmd/ensure/internal/mockgen/scenarios/generics_multiple_type_params/pkg1.expected
@@ -53,11 +53,11 @@ func (m *MockThingable[T, V]) Identity(_in T) T {
 //
 // Inputs:
 //
-//  in T
+//	in T
 //
 // Outputs:
 //
-//  T
+//	T
 func (mr *MockThingableMockRecorder[T, V]) Identity(_in interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	inputs := []interface{}{_in}
@@ -78,11 +78,11 @@ func (m *MockThingable[T, V]) Transform(_in T) V {
 //
 // Inputs:
 //
-//  in T
+//	in T
 //
 // Outputs:
 //
-//  V
+//	V
 func (mr *MockThingableMockRecorder[T, V]) Transform(_in interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	inputs := []interface{}{_in}

--- a/cmd/ensure/internal/mockgen/scenarios/generics_single_type_param/pkg1.expected
+++ b/cmd/ensure/internal/mockgen/scenarios/generics_single_type_param/pkg1.expected
@@ -51,11 +51,11 @@ func (m *MockIdentifier[T]) Identity(_in T) T {
 //
 // Inputs:
 //
-//  in T
+//	in T
 //
 // Outputs:
 //
-//  T
+//	T
 func (mr *MockIdentifierMockRecorder[T]) Identity(_in interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	inputs := []interface{}{_in}

--- a/cmd/ensure/internal/mockgen/scenarios/multiple_interfaces/pkg1.expected
+++ b/cmd/ensure/internal/mockgen/scenarios/multiple_interfaces/pkg1.expected
@@ -52,13 +52,13 @@ func (m *MockStringTransformable) TransformString(_prefix string, _str string) (
 //
 // Inputs:
 //
-//  prefix string
-//  str string
+//	prefix string
+//	str string
 //
 // Outputs:
 //
-//  string
-//  error
+//	string
+//	error
 func (mr *MockStringTransformableMockRecorder) TransformString(_prefix interface{}, _str interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	inputs := []interface{}{_prefix, _str}
@@ -107,11 +107,11 @@ func (m *MockNumberTransformable) TransformInt(_i int) int {
 //
 // Inputs:
 //
-//  i int
+//	i int
 //
 // Outputs:
 //
-//  int
+//	int
 func (mr *MockNumberTransformableMockRecorder) TransformInt(_i interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	inputs := []interface{}{_i}
@@ -132,11 +132,11 @@ func (m *MockNumberTransformable) TransformFloat64(_f float64) float64 {
 //
 // Inputs:
 //
-//  f float64
+//	f float64
 //
 // Outputs:
 //
-//  float64
+//	float64
 func (mr *MockNumberTransformableMockRecorder) TransformFloat64(_f interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	inputs := []interface{}{_f}

--- a/cmd/ensure/internal/mockgen/scenarios/single_interface_multiple_methods/pkg1.expected
+++ b/cmd/ensure/internal/mockgen/scenarios/single_interface_multiple_methods/pkg1.expected
@@ -52,13 +52,13 @@ func (m *MockTransformable) TransformString(_prefix string, _str string) (string
 //
 // Inputs:
 //
-//  prefix string
-//  str string
+//	prefix string
+//	str string
 //
 // Outputs:
 //
-//  string
-//  error
+//	string
+//	error
 func (mr *MockTransformableMockRecorder) TransformString(_prefix interface{}, _str interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	inputs := []interface{}{_prefix, _str}
@@ -79,11 +79,11 @@ func (m *MockTransformable) TransformFloat64(_f float64) float64 {
 //
 // Inputs:
 //
-//  f float64
+//	f float64
 //
 // Outputs:
 //
-//  float64
+//	float64
 func (mr *MockTransformableMockRecorder) TransformFloat64(_f interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	inputs := []interface{}{_f}

--- a/cmd/ensure/internal/mockgen/scenarios/single_method_external_imports/pkg1.expected
+++ b/cmd/ensure/internal/mockgen/scenarios/single_method_external_imports/pkg1.expected
@@ -53,12 +53,12 @@ func (m *MockTransformable) Transform(_user *external1.User, _message *external2
 //
 // Inputs:
 //
-//  user *external1.User
-//  message *external2.Message
+//	user *external1.User
+//	message *external2.Message
 //
 // Outputs:
 //
-//  external1.String
+//	external1.String
 func (mr *MockTransformableMockRecorder) Transform(_user interface{}, _message interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	inputs := []interface{}{_user, _message}

--- a/cmd/ensure/internal/mockgen/scenarios/single_method_external_imports_clash_with_required/pkg1.expected
+++ b/cmd/ensure/internal/mockgen/scenarios/single_method_external_imports_clash_with_required/pkg1.expected
@@ -53,12 +53,12 @@ func (m *MockDoable) Do(_thing *reflect.Thing, _other *gomock.Other) {
 //
 // Inputs:
 //
-//  thing *reflect.Thing
-//  other *gomock.Other
+//	thing *reflect.Thing
+//	other *gomock.Other
 //
 // Outputs:
 //
-//  none
+//	none
 func (mr *MockDoableMockRecorder) Do(_thing interface{}, _other interface{}) *gomock2.Call {
 	mr.mock.ctrl.T.Helper()
 	inputs := []interface{}{_thing, _other}

--- a/cmd/ensure/internal/mockgen/scenarios/single_method_external_imports_with_aliases/pkg1.expected
+++ b/cmd/ensure/internal/mockgen/scenarios/single_method_external_imports_with_aliases/pkg1.expected
@@ -53,12 +53,12 @@ func (m *MockTransformable) Transform(_user *models.User, _message *models2.Mess
 //
 // Inputs:
 //
-//  user *models.User
-//  message *models2.Message
+//	user *models.User
+//	message *models2.Message
 //
 // Outputs:
 //
-//  models.String
+//	models.String
 func (mr *MockTransformableMockRecorder) Transform(_user interface{}, _message interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	inputs := []interface{}{_user, _message}

--- a/cmd/ensure/internal/mockgen/scenarios/single_method_multiple_params/pkg1.expected
+++ b/cmd/ensure/internal/mockgen/scenarios/single_method_multiple_params/pkg1.expected
@@ -52,13 +52,13 @@ func (m *MockTransformable) TransformString(_prefix string, _str string) (string
 //
 // Inputs:
 //
-//  prefix string
-//  str string
+//	prefix string
+//	str string
 //
 // Outputs:
 //
-//  string
-//  error
+//	string
+//	error
 func (mr *MockTransformableMockRecorder) TransformString(_prefix interface{}, _str interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	inputs := []interface{}{_prefix, _str}

--- a/cmd/ensure/internal/mockgen/scenarios/single_method_named_outputs/pkg1.expected
+++ b/cmd/ensure/internal/mockgen/scenarios/single_method_named_outputs/pkg1.expected
@@ -52,13 +52,13 @@ func (m *MockTransformable) TransformString(_prefix string, _str string) (_trans
 //
 // Inputs:
 //
-//  prefix string
-//  str string
+//	prefix string
+//	str string
 //
 // Outputs:
 //
-//  transformedStr string
-//  err error
+//	transformedStr string
+//	err error
 func (mr *MockTransformableMockRecorder) TransformString(_prefix interface{}, _str interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	inputs := []interface{}{_prefix, _str}

--- a/cmd/ensure/internal/mockgen/scenarios/single_method_no_imports/pkg1.expected
+++ b/cmd/ensure/internal/mockgen/scenarios/single_method_no_imports/pkg1.expected
@@ -51,11 +51,11 @@ func (m *MockTransformable) TransformString(_str string) string {
 //
 // Inputs:
 //
-//  str string
+//	str string
 //
 // Outputs:
 //
-//  string
+//	string
 func (mr *MockTransformableMockRecorder) TransformString(_str interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	inputs := []interface{}{_str}

--- a/cmd/ensure/internal/mockgen/scenarios/single_method_no_params/noop.expected
+++ b/cmd/ensure/internal/mockgen/scenarios/single_method_no_params/noop.expected
@@ -51,11 +51,11 @@ func (m *MockNoopable) Noop() {
 //
 // Inputs:
 //
-//  none
+//	none
 //
 // Outputs:
 //
-//  none
+//	none
 func (mr *MockNoopableMockRecorder) Noop() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	inputs := []interface{}{}

--- a/cmd/ensure/internal/mockgen/scenarios/single_method_unnamed_inputs/pkg1.expected
+++ b/cmd/ensure/internal/mockgen/scenarios/single_method_unnamed_inputs/pkg1.expected
@@ -52,13 +52,13 @@ func (m *MockTransformable) TransformString(_arg0 string, _arg1 string) (string,
 //
 // Inputs:
 //
-//  string
-//  string
+//	string
+//	string
 //
 // Outputs:
 //
-//  string
-//  error
+//	string
+//	error
 func (mr *MockTransformableMockRecorder) TransformString(_arg0 interface{}, _arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	inputs := []interface{}{_arg0, _arg1}

--- a/cmd/ensure/internal/mockgen/scenarios/single_method_variadic_input/pkg1.expected
+++ b/cmd/ensure/internal/mockgen/scenarios/single_method_variadic_input/pkg1.expected
@@ -55,13 +55,13 @@ func (m *MockTransformable) TransformString(_prefix string, _strs ...string) (st
 //
 // Inputs:
 //
-//  prefix string
-//  strs ...string
+//	prefix string
+//	strs ...string
 //
 // Outputs:
 //
-//  string
-//  error
+//	string
+//	error
 func (mr *MockTransformableMockRecorder) TransformString(_prefix interface{}, _strs ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	inputs := []interface{}{_prefix}

--- a/cmd/ensure/internal/mockgen/template.go
+++ b/cmd/ensure/internal/mockgen/template.go
@@ -83,11 +83,11 @@ func (m *{{buildMockStructName $iface}}) {{$method.Name}}({{buildInputSignature 
 //
 // Inputs:
 //
-//  {{buildParamsDoc $method.Inputs}}
+//	{{buildParamsDoc $method.Inputs}}
 //
 // Outputs:
 //
-//  {{buildParamsDoc $method.Outputs}}
+//	{{buildParamsDoc $method.Outputs}}
 func (mr *{{buildMockRecorderStructName $iface}}) {{$method.Name}}({{buildMockInputSignature $method.Inputs}}) *{{$params.GoMockPackageName}}.Call {
 	mr.mock.ctrl.T.Helper()
 	{{buildInputsSlice $method.Inputs}}
@@ -252,7 +252,7 @@ func templateFuncBuildParamsDoc(params []*ifacereader.Tuple) string {
 		builtParams = append(builtParams, builtParam)
 	}
 
-	return strings.Join(builtParams, "\n//  ")
+	return strings.Join(builtParams, "\n//	")
 }
 
 func preprocessParams(params []*ifacereader.Tuple, originalVarName bool) []*ifacereader.Tuple {

--- a/cmd/ensure/internal/mocks/io/mock_fs/mock_fs.go
+++ b/cmd/ensure/internal/mocks/io/mock_fs/mock_fs.go
@@ -53,12 +53,12 @@ func (m *MockReadFileFS) Open(_name string) (fs.File, error) {
 //
 // Inputs:
 //
-//  name string
+//	name string
 //
 // Outputs:
 //
-//  fs.File
-//  error
+//	fs.File
+//	error
 func (mr *MockReadFileFSMockRecorder) Open(_name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	inputs := []interface{}{_name}
@@ -80,12 +80,12 @@ func (m *MockReadFileFS) ReadFile(_name string) ([]byte, error) {
 //
 // Inputs:
 //
-//  name string
+//	name string
 //
 // Outputs:
 //
-//  []byte
-//  error
+//	[]byte
+//	error
 func (mr *MockReadFileFSMockRecorder) ReadFile(_name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	inputs := []interface{}{_name}

--- a/cmd/ensure/internal/mocks/mock_ensurefile/mock_ensurefile.go
+++ b/cmd/ensure/internal/mocks/mock_ensurefile/mock_ensurefile.go
@@ -53,12 +53,12 @@ func (m *MockLoaderIface) LoadConfig(_pwd string) (*ensurefile.Config, error) {
 //
 // Inputs:
 //
-//  pwd string
+//	pwd string
 //
 // Outputs:
 //
-//  *ensurefile.Config
-//  error
+//	*ensurefile.Config
+//	error
 func (mr *MockLoaderIfaceMockRecorder) LoadConfig(_pwd interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	inputs := []interface{}{_pwd}

--- a/cmd/ensure/internal/mocks/mock_fswrite/mock_fswrite.go
+++ b/cmd/ensure/internal/mocks/mock_fswrite/mock_fswrite.go
@@ -53,12 +53,12 @@ func (m *MockWritable) ListRecursive(_dir string) ([]string, error) {
 //
 // Inputs:
 //
-//  dir string
+//	dir string
 //
 // Outputs:
 //
-//  []string
-//  error
+//	[]string
+//	error
 func (mr *MockWritableMockRecorder) ListRecursive(_dir interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	inputs := []interface{}{_dir}
@@ -79,12 +79,12 @@ func (m *MockWritable) MkdirAll(_path string, _perm fs.FileMode) error {
 //
 // Inputs:
 //
-//  path string
-//  perm fs.FileMode
+//	path string
+//	perm fs.FileMode
 //
 // Outputs:
 //
-//  error
+//	error
 func (mr *MockWritableMockRecorder) MkdirAll(_path interface{}, _perm interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	inputs := []interface{}{_path, _perm}
@@ -105,11 +105,11 @@ func (m *MockWritable) RemoveAll(_paths string) error {
 //
 // Inputs:
 //
-//  paths string
+//	paths string
 //
 // Outputs:
 //
-//  error
+//	error
 func (mr *MockWritableMockRecorder) RemoveAll(_paths interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	inputs := []interface{}{_paths}
@@ -130,13 +130,13 @@ func (m *MockWritable) WriteFile(_filename string, _data string, _perm fs.FileMo
 //
 // Inputs:
 //
-//  filename string
-//  data string
-//  perm fs.FileMode
+//	filename string
+//	data string
+//	perm fs.FileMode
 //
 // Outputs:
 //
-//  error
+//	error
 func (mr *MockWritableMockRecorder) WriteFile(_filename interface{}, _data interface{}, _perm interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	inputs := []interface{}{_filename, _data, _perm}

--- a/cmd/ensure/internal/mocks/mock_ifacereader/mock_ifacereader.go
+++ b/cmd/ensure/internal/mocks/mock_ifacereader/mock_ifacereader.go
@@ -53,13 +53,13 @@ func (m *MockReadable) ReadPackages(_pkgDetails []*ifacereader.PackageDetails, _
 //
 // Inputs:
 //
-//  pkgDetails []*ifacereader.PackageDetails
-//  pkgNameGen ifacereader.PackageNameGenerator
+//	pkgDetails []*ifacereader.PackageDetails
+//	pkgNameGen ifacereader.PackageNameGenerator
 //
 // Outputs:
 //
-//  []*ifacereader.Package
-//  error
+//	[]*ifacereader.Package
+//	error
 func (mr *MockReadableMockRecorder) ReadPackages(_pkgDetails interface{}, _pkgNameGen interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	inputs := []interface{}{_pkgDetails, _pkgNameGen}

--- a/cmd/ensure/internal/mocks/mock_mockgen/mock_mockgen.go
+++ b/cmd/ensure/internal/mocks/mock_mockgen/mock_mockgen.go
@@ -55,13 +55,13 @@ func (m *MockGenerator) GenerateMocks(_pkgs []*ifacereader.Package, _imports *un
 //
 // Inputs:
 //
-//  pkgs []*ifacereader.Package
-//  imports *uniqpkg.UniquePackagePaths
+//	pkgs []*ifacereader.Package
+//	imports *uniqpkg.UniquePackagePaths
 //
 // Outputs:
 //
-//  []*mockgen.PackageMock
-//  error
+//	[]*mockgen.PackageMock
+//	error
 func (mr *MockGeneratorMockRecorder) GenerateMocks(_pkgs interface{}, _imports interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	inputs := []interface{}{_pkgs, _imports}

--- a/cmd/ensure/internal/mocks/mock_mockwrite/mock_mockwrite.go
+++ b/cmd/ensure/internal/mocks/mock_mockwrite/mock_mockwrite.go
@@ -54,12 +54,12 @@ func (m *MockWritable) TidyMocks(_config *ensurefile.Config, _packages []*ifacer
 //
 // Inputs:
 //
-//  config *ensurefile.Config
-//  packages []*ifacereader.Package
+//	config *ensurefile.Config
+//	packages []*ifacereader.Package
 //
 // Outputs:
 //
-//  error
+//	error
 func (mr *MockWritableMockRecorder) TidyMocks(_config interface{}, _packages interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	inputs := []interface{}{_config, _packages}
@@ -80,12 +80,12 @@ func (m *MockWritable) WriteMocks(_config *ensurefile.Config, _mocks []*mockgen.
 //
 // Inputs:
 //
-//  config *ensurefile.Config
-//  mocks []*mockgen.PackageMock
+//	config *ensurefile.Config
+//	mocks []*mockgen.PackageMock
 //
 // Outputs:
 //
-//  error
+//	error
 func (mr *MockWritableMockRecorder) WriteMocks(_config interface{}, _mocks interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	inputs := []interface{}{_config, _mocks}

--- a/cmd/ensure/internal/mockwrite/mockwrite_test.go
+++ b/cmd/ensure/internal/mockwrite/mockwrite_test.go
@@ -2,8 +2,8 @@ package mockwrite_test
 
 import (
 	"errors"
+	"io"
 	"io/fs"
-	"io/ioutil"
 	"log"
 	"testing"
 
@@ -500,7 +500,7 @@ func TestWriteMocks(t *testing.T) {
 
 	ensure.RunTableByIndex(table, func(ensure ensurepkg.Ensure, i int) {
 		entry := table[i]
-		entry.Subject.Logger = log.New(ioutil.Discard, "", 0)
+		entry.Subject.Logger = log.New(io.Discard, "", 0)
 
 		err := entry.Subject.WriteMocks(entry.Config, entry.GeneratedMocks)
 		ensure(err).IsError(entry.ExpectedError)

--- a/cmd/ensure/internal/mockwrite/tidy_mocks_test.go
+++ b/cmd/ensure/internal/mockwrite/tidy_mocks_test.go
@@ -2,7 +2,7 @@ package mockwrite_test
 
 import (
 	"errors"
-	"io/ioutil"
+	"io"
 	"log"
 	"testing"
 
@@ -322,7 +322,7 @@ func TestTidyMocks(t *testing.T) {
 
 	ensure.RunTableByIndex(table, func(ensure ensurepkg.Ensure, i int) {
 		entry := table[i]
-		entry.Subject.Logger = log.New(ioutil.Discard, "", 0)
+		entry.Subject.Logger = log.New(io.Discard, "", 0)
 
 		err := entry.Subject.TidyMocks(entry.Config, entry.Packages)
 		ensure(err).IsError(entry.ExpectedError)

--- a/cmd/ensure/main.go
+++ b/cmd/ensure/main.go
@@ -13,9 +13,10 @@ import (
 	"github.com/JosiahWitt/ensure/cmd/ensure/internal/mockwrite"
 )
 
-//nolint:gochecknoglobals // Allows injecting the version
 // Version of the CLI.
 // Should be tied to the release version.
+//
+//nolint:gochecknoglobals // Allows injecting the version
 var Version = "0.3.1"
 
 func main() {

--- a/ensure.go
+++ b/ensure.go
@@ -7,26 +7,27 @@
 // This provides easy test refactoring, while still being able to access the underlying types via the ensurepkg package.
 //
 // For example:
-//  func TestBasicExample(t *testing.T) {
-//   ensure := ensure.New(t)
-//   ...
 //
-//   // Methods can be called on ensure, for example, Run:
-//   ensure.Run("my subtest", func(ensure ensurepkg.Ensure) {
-//     ...
+//	func TestBasicExample(t *testing.T) {
+//	 ensure := ensure.New(t)
+//	 ...
 //
-//   	 // To ensure a value is correct, use ensure as a function:
-//   	 ensure("abc").Equals("abc")
-//   	 ensure(produceError()).IsError(expectedError)
-//   	 ensure(doNotProduceError()).IsNotError()
-//   	 ensure(true).IsTrue()
-//   	 ensure(false).IsFalse()
-//   	 ensure("").IsEmpty()
+//	 // Methods can be called on ensure, for example, Run:
+//	 ensure.Run("my subtest", func(ensure ensurepkg.Ensure) {
+//	   ...
 //
-//     // Failing a test directly:
-//     ensure.Failf("Something went wrong, and we stop the test immediately")
-//   })
-//  }
+//	 	 // To ensure a value is correct, use ensure as a function:
+//	 	 ensure("abc").Equals("abc")
+//	 	 ensure(produceError()).IsError(expectedError)
+//	 	 ensure(doNotProduceError()).IsNotError()
+//	 	 ensure(true).IsTrue()
+//	 	 ensure(false).IsFalse()
+//	 	 ensure("").IsEmpty()
+//
+//	   // Failing a test directly:
+//	   ensure.Failf("Something went wrong, and we stop the test immediately")
+//	 })
+//	}
 package ensure
 
 import "github.com/JosiahWitt/ensure/ensurepkg"

--- a/ensurepkg/chain.go
+++ b/ensurepkg/chain.go
@@ -14,6 +14,7 @@ import (
 )
 
 // Mutex to synchronize accessing deep.
+//
 //nolint:gochecknoglobals // Deep global variables need a global mutex.
 var deepGlobalMu sync.Mutex
 
@@ -130,11 +131,12 @@ func (c *Chain) IsNotEmpty() {
 // If both the actual and expected are strings, strings.Contains(...) is used.
 //
 // For example:
-//  ensure("abc").Contains("b") // Succeeds
-//  ensure("abc").Contains("z") // Fails
 //
-//  ensure([]string{"abc", "xyz"}).Contains("xyz") // Succeeds
-//  ensure([]string{"abc", "xyz"}).Contains("y") // Fails
+//	ensure("abc").Contains("b") // Succeeds
+//	ensure("abc").Contains("z") // Fails
+//
+//	ensure([]string{"abc", "xyz"}).Contains("xyz") // Succeeds
+//	ensure([]string{"abc", "xyz"}).Contains("y") // Fails
 func (c *Chain) Contains(expected interface{}) {
 	c.t.Helper()
 	c.markRun()
@@ -159,11 +161,12 @@ func (c *Chain) Contains(expected interface{}) {
 // If both the actual and expected are strings, strings.Contains(...) is used.
 //
 // For example:
-//  ensure("abc").DoesNotContain("b") // Fails
-//  ensure("abc").DoesNotContain("z") // Succeeds
 //
-//  ensure([]string{"abc", "xyz"}).DoesNotContain("xyz") // Fails
-//  ensure([]string{"abc", "xyz"}).DoesNotContain("y") // Succeeds
+//	ensure("abc").DoesNotContain("b") // Fails
+//	ensure("abc").DoesNotContain("z") // Succeeds
+//
+//	ensure([]string{"abc", "xyz"}).DoesNotContain("xyz") // Fails
+//	ensure([]string{"abc", "xyz"}).DoesNotContain("y") // Succeeds
 func (c *Chain) DoesNotContain(expected interface{}) {
 	c.t.Helper()
 	c.markRun()

--- a/ensurepkg/run_table.go
+++ b/ensurepkg/run_table.go
@@ -80,29 +80,30 @@ type tableEntry struct {
 // The fn is executed for each entry, with a scoped ensure instance and an index for an entry in the table.
 //
 // For example:
-//  table := []struct {
-//    Name    string
-//    Input   string
-//    IsEmpty bool
-//  }{
-//    {
-//      Name:    "with non empty input",
-//      Input:   "my string",
-//      IsEmpty: false,
-//    },
-//    {
-//      Name:    "with empty input",
-//      Input:   "",
-//      IsEmpty: true,
-//    },
-//  }
 //
-//  ensure.RunTableByIndex(table, func(ensure Ensure, i int) {
-//    entry := table[i]
+//	table := []struct {
+//	  Name    string
+//	  Input   string
+//	  IsEmpty bool
+//	}{
+//	  {
+//	    Name:    "with non empty input",
+//	    Input:   "my string",
+//	    IsEmpty: false,
+//	  },
+//	  {
+//	    Name:    "with empty input",
+//	    Input:   "",
+//	    IsEmpty: true,
+//	  },
+//	}
 //
-//    isEmpty := strs.IsEmpty(entry.Input)
-//    ensure(isEmpty).Equals(entry.IsEmpty)
-//  })
+//	ensure.RunTableByIndex(table, func(ensure Ensure, i int) {
+//	  entry := table[i]
+//
+//	  isEmpty := strs.IsEmpty(entry.Input)
+//	  ensure(isEmpty).Equals(entry.IsEmpty)
+//	})
 //
 // Support for mocks is also included.
 // Please see the README for an example.

--- a/internal/mocks/github.com/JosiahWitt/ensure/mock_ensurepkg/mock_ensurepkg.go
+++ b/internal/mocks/github.com/JosiahWitt/ensure/mock_ensurepkg/mock_ensurepkg.go
@@ -52,11 +52,11 @@ func (m *MockT) Cleanup(_arg0 func()) {
 //
 // Inputs:
 //
-//  func()
+//	func()
 //
 // Outputs:
 //
-//  none
+//	none
 func (mr *MockTMockRecorder) Cleanup(_arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	inputs := []interface{}{_arg0}
@@ -80,12 +80,12 @@ func (m *MockT) Errorf(_format string, _args ...interface{}) {
 //
 // Inputs:
 //
-//  format string
-//  args ...interface{}
+//	format string
+//	args ...interface{}
 //
 // Outputs:
 //
-//  none
+//	none
 func (mr *MockTMockRecorder) Errorf(_format interface{}, _args ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	inputs := []interface{}{_format}
@@ -112,12 +112,12 @@ func (m *MockT) Fatalf(_format string, _args ...interface{}) {
 //
 // Inputs:
 //
-//  format string
-//  args ...interface{}
+//	format string
+//	args ...interface{}
 //
 // Outputs:
 //
-//  none
+//	none
 func (mr *MockTMockRecorder) Fatalf(_format interface{}, _args ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	inputs := []interface{}{_format}
@@ -141,11 +141,11 @@ func (m *MockT) Helper() {
 //
 // Inputs:
 //
-//  none
+//	none
 //
 // Outputs:
 //
-//  none
+//	none
 func (mr *MockTMockRecorder) Helper() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	inputs := []interface{}{}
@@ -169,12 +169,12 @@ func (m *MockT) Logf(_format string, _args ...interface{}) {
 //
 // Inputs:
 //
-//  format string
-//  args ...interface{}
+//	format string
+//	args ...interface{}
 //
 // Outputs:
 //
-//  none
+//	none
 func (mr *MockTMockRecorder) Logf(_format interface{}, _args ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	inputs := []interface{}{_format}
@@ -198,12 +198,12 @@ func (m *MockT) Run(_name string, _f func(t *testing.T)) bool {
 //
 // Inputs:
 //
-//  name string
-//  f func(t *testing.T)
+//	name string
+//	f func(t *testing.T)
 //
 // Outputs:
 //
-//  bool
+//	bool
 func (mr *MockTMockRecorder) Run(_name interface{}, _f interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	inputs := []interface{}{_name, _f}


### PR DESCRIPTION
Go 1.19 changes two spaces to a tab to indicate a code block in a doc comment. This updates the project to support that syntax.