### PR TITLE
Enhance `IsNil`, `IsError`, and `MatchesAllErrors`

### DIFF
--- a/cmd/ensure/main.go
+++ b/cmd/ensure/main.go
@@ -17,7 +17,7 @@ import (
 // Should be tied to the release version.
 //
 //nolint:gochecknoglobals // Allows injecting the version
-var Version = "0.3.1"
+var Version = "0.3.3"
 
 func main() {
 	if err := run(); err != nil {
@@ -39,7 +39,7 @@ func run() error {
 
 		Logger:           logger,
 		Getwd:            os.Getwd,
-		EnsureFileLoader: &ensurefile.Loader{FS: os.DirFS("")},
+		EnsureFileLoader: &ensurefile.Loader{FS: os.DirFS("/")},
 		InterfaceReader:  &ifacereader.InterfaceReader{},
 		MockGenerator:    mockGen,
 		MockWriter: &mockwrite.MockWriter{

--- a/ensurepkg/chain.go
+++ b/ensurepkg/chain.go
@@ -232,9 +232,13 @@ func isNil(value interface{}) bool {
 		return true
 	}
 
-	reflection := reflect.ValueOf(value)
-	isNilPointer := reflection.Kind() == reflect.Ptr && reflection.IsNil()
-	return isNilPointer
+	//nolint:exhaustive // We don't want to be exhaustive here
+	switch val := reflect.ValueOf(value); val.Kind() {
+	case reflect.Ptr, reflect.Slice, reflect.Map, reflect.Func, reflect.Chan:
+		return val.IsNil()
+	default:
+		return false
+	}
 }
 
 func lengthOf(value interface{}) (int, error) {

--- a/ensurepkg/chain_error.go
+++ b/ensurepkg/chain_error.go
@@ -13,12 +13,12 @@ func (c *Chain) IsError(expected error) {
 	c.t.Helper()
 	c.markRun()
 
-	if c.actual == nil && expected == nil {
+	if isNil(c.actual) && isNil(expected) {
 		return
 	}
 
 	actual, ok := c.actual.(error)
-	if !ok && c.actual != nil {
+	if !ok && !isNil(c.actual) {
 		c.t.Fatalf("Got type %T, expected error: \"%v\"", c.actual, expected)
 		return
 	}
@@ -41,13 +41,13 @@ func (c *Chain) MatchesAllErrors(expectedErrors ...error) {
 	c.markRun()
 
 	actual, ok := c.actual.(error)
-	if !ok && c.actual != nil {
+	if !ok && !isNil(c.actual) {
 		c.t.Fatalf("Got type %T, expected an error", c.actual)
 		return
 	}
 
 	if len(expectedErrors) == 0 {
-		if c.actual != nil {
+		if !isNil(c.actual) {
 			c.t.Fatalf("\nExpected no error, but got: %s", buildActualErrorOutput(actual))
 		}
 

--- a/ensurepkg/chain_test.go
+++ b/ensurepkg/chain_test.go
@@ -77,6 +77,8 @@ func TestChainIsFalse(t *testing.T) {
 }
 
 func TestChainIsNil(t *testing.T) {
+	const failureFormat = "Got %+v, expected nil"
+
 	t.Run("when nil", func(t *testing.T) {
 		mockT := setupMockTWithCleanupCheck(t)
 		mockT.EXPECT().Helper()
@@ -85,26 +87,167 @@ func TestChainIsNil(t *testing.T) {
 		ensure(nil).IsNil()
 	})
 
-	t.Run("when nil pointer", func(t *testing.T) {
-		mockT := setupMockTWithCleanupCheck(t)
-		mockT.EXPECT().Helper()
-
-		var nilPtr *string
-
-		ensure := ensure.New(mockT)
-		ensure(nilPtr).IsNil()
-	})
-
-	t.Run("when not nil", func(t *testing.T) {
+	t.Run("not nilable", func(t *testing.T) {
 		mockT := setupMockTWithCleanupCheck(t)
 
 		const val = "not nil"
-		mockT.EXPECT().Fatalf("Got %+v, expected nil", val).After(
+		mockT.EXPECT().Fatalf(failureFormat, val).After(
 			mockT.EXPECT().Helper(),
 		)
 
 		ensure := ensure.New(mockT)
 		ensure(val).IsNil()
+	})
+
+	t.Run("pointer", func(t *testing.T) {
+		t.Run("when nil", func(t *testing.T) {
+			mockT := setupMockTWithCleanupCheck(t)
+			mockT.EXPECT().Helper()
+
+			var ptr *string
+
+			ensure := ensure.New(mockT)
+			ensure(ptr).IsNil()
+		})
+
+		t.Run("when not nil", func(t *testing.T) {
+			mockT := setupMockTWithCleanupCheck(t)
+
+			val := "not nil"
+			ptr := &val
+
+			mockT.EXPECT().Fatalf(failureFormat, ptr).After(
+				mockT.EXPECT().Helper(),
+			)
+
+			ensure := ensure.New(mockT)
+			ensure(ptr).IsNil()
+		})
+	})
+
+	t.Run("slice", func(t *testing.T) {
+		t.Run("when nil", func(t *testing.T) {
+			mockT := setupMockTWithCleanupCheck(t)
+			mockT.EXPECT().Helper()
+
+			var nilSlice []string
+
+			ensure := ensure.New(mockT)
+			ensure(nilSlice).IsNil()
+		})
+
+		t.Run("when not nil", func(t *testing.T) {
+			mockT := setupMockTWithCleanupCheck(t)
+
+			slice := []string{}
+
+			mockT.EXPECT().Fatalf(failureFormat, slice).After(
+				mockT.EXPECT().Helper(),
+			)
+
+			ensure := ensure.New(mockT)
+			ensure(slice).IsNil()
+		})
+	})
+
+	t.Run("map", func(t *testing.T) {
+		t.Run("when nil", func(t *testing.T) {
+			mockT := setupMockTWithCleanupCheck(t)
+			mockT.EXPECT().Helper()
+
+			var nilMap map[string]string
+
+			ensure := ensure.New(mockT)
+			ensure(nilMap).IsNil()
+		})
+
+		t.Run("when not nil", func(t *testing.T) {
+			mockT := setupMockTWithCleanupCheck(t)
+
+			m := map[string]string{}
+
+			mockT.EXPECT().Fatalf(failureFormat, m).After(
+				mockT.EXPECT().Helper(),
+			)
+
+			ensure := ensure.New(mockT)
+			ensure(m).IsNil()
+		})
+	})
+
+	t.Run("func", func(t *testing.T) {
+		t.Run("when nil", func(t *testing.T) {
+			mockT := setupMockTWithCleanupCheck(t)
+			mockT.EXPECT().Helper()
+
+			var nilFunc func(string) string
+
+			ensure := ensure.New(mockT)
+			ensure(nilFunc).IsNil()
+		})
+
+		t.Run("when not nil", func(t *testing.T) {
+			mockT := setupMockTWithCleanupCheck(t)
+
+			f := func(s string) string { return "hello, " + s }
+
+			mockT.EXPECT().Fatalf(failureFormat, gomock.Any()).After(
+				mockT.EXPECT().Helper(),
+			)
+
+			ensure := ensure.New(mockT)
+			ensure(f).IsNil()
+		})
+	})
+
+	t.Run("chan", func(t *testing.T) {
+		t.Run("when nil", func(t *testing.T) {
+			mockT := setupMockTWithCleanupCheck(t)
+			mockT.EXPECT().Helper()
+
+			var nilChan chan string
+
+			ensure := ensure.New(mockT)
+			ensure(nilChan).IsNil()
+		})
+
+		t.Run("when not nil", func(t *testing.T) {
+			mockT := setupMockTWithCleanupCheck(t)
+
+			c := make(chan string)
+
+			mockT.EXPECT().Fatalf(failureFormat, c).After(
+				mockT.EXPECT().Helper(),
+			)
+
+			ensure := ensure.New(mockT)
+			ensure(c).IsNil()
+		})
+	})
+
+	t.Run("interface", func(t *testing.T) {
+		t.Run("when nil", func(t *testing.T) {
+			mockT := setupMockTWithCleanupCheck(t)
+			mockT.EXPECT().Helper()
+
+			var nilInterface interface{ Hello(string) string }
+
+			ensure := ensure.New(mockT)
+			ensure(nilInterface).IsNil()
+		})
+
+		t.Run("when not nil", func(t *testing.T) {
+			mockT := setupMockTWithCleanupCheck(t)
+
+			var iface interface{ Hello(string) string } = &ExampleGreeter{}
+
+			mockT.EXPECT().Fatalf(failureFormat, iface).After(
+				mockT.EXPECT().Helper(),
+			)
+
+			ensure := ensure.New(mockT)
+			ensure(iface).IsNil()
+		})
 	})
 }
 
@@ -987,4 +1130,10 @@ type ExamplePerson struct {
 
 func (p ExamplePerson) ExpectedOutput() string {
 	return text.Indent(pretty.Sprint(p), "  ")
+}
+
+type ExampleGreeter struct{}
+
+func (*ExampleGreeter) Hello(s string) string {
+	return "hello, " + s
 }

--- a/ensurepkg/ensurepkg.go
+++ b/ensurepkg/ensurepkg.go
@@ -25,7 +25,7 @@ type T interface {
 // Ensure also has methods that can be called directly.
 type Ensure func(actual interface{}) *Chain
 
-// Chain assetions to the ensure function call.
+// Chain assertions to the ensure function call.
 type Chain struct {
 	t      T
 	actual interface{}

--- a/ensurepkg/run.go
+++ b/ensurepkg/run.go
@@ -15,8 +15,8 @@ func (c *Chain) run(name string, fn func(ensure Ensure)) {
 	c.t.Helper()
 	c.markRun()
 
-	//nolint:thelper // We already tag it as a test helper
 	c.t.Run(name, func(t *testing.T) {
+		t.Helper()
 		ensure := wrap(t)
 		fn(ensure)
 	})


### PR DESCRIPTION
Now `nil` is handled correctly for slices, maps, channels, and functions in `IsNil`, `IsError`, and `MatchesAllErrors`. It also fixes passing in the empty string to `os.DirFS` in the CLI.