### PR TITLE
Add optional `ensuring.E` parameter to `SetupMocks`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,3 +46,7 @@ issues:
         - ifshort
         - thelper
         - maintidx
+
+    - text: singleCaseSwitch
+      linters:
+        - gocritic

--- a/cmd/ensure/.golangci.yml
+++ b/cmd/ensure/.golangci.yml
@@ -48,6 +48,10 @@ issues:
         - thelper
         - maintidx
 
+    - text: singleCaseSwitch
+      linters:
+        - gocritic
+
     # Exclude some linters from fixtures and scenarios
     - path: .*(/fixtures/)|(/scenarios/).*
       linters:

--- a/ensuring/ensuring.go
+++ b/ensuring/ensuring.go
@@ -14,7 +14,7 @@ import (
 )
 
 //nolint:gochecknoglobals // This is stored as a variable so we can override it for tests in init_test.go.
-var newTestContext = testctx.New
+var newTestContextFunc = testctx.New
 
 // T implements a subset of methods on [testing.T].
 // More methods may be added to T with a minor ensure release.
@@ -117,4 +117,8 @@ func wrap(t T) E {
 
 		return c
 	}
+}
+
+func newTestContext(t T) testctx.Context {
+	return newTestContextFunc(t, func(t testctx.T) interface{} { return wrap(t) })
 }

--- a/ensuring/ensuring_test.go
+++ b/ensuring/ensuring_test.go
@@ -188,7 +188,7 @@ func setupMockT(t *testing.T) *mock_testctx.MockT {
 	ctrl := gomock.NewController(t)
 	mockT := mock_testctx.NewMockT(ctrl)
 
-	testhelper.SetTestContext(t, mockT, testctx.New(mockT))
+	testhelper.SetTestContext(t, mockT, testctx.New(mockT, wrapEnsure))
 	return mockT
 }
 
@@ -204,4 +204,8 @@ func setupMockTWithCleanupCheck(t *testing.T) *mock_testctx.MockT {
 	)
 
 	return mockT
+}
+
+func wrapEnsure(t testctx.T) interface{} {
+	return ensure.New(t)
 }

--- a/ensuring/init_test.go
+++ b/ensuring/init_test.go
@@ -5,8 +5,8 @@ import "github.com/JosiahWitt/ensure/ensuring/internal/testhelper"
 
 //nolint:gochecknoinits // Only to make testing easier.
 func init() {
-	// Initializes the unexported newTestContext variable to use the test implementation.
-	// This allows us to continue to keep the tests in the separate testing package and
-	// keep the newTestContext variable unexported.
-	newTestContext = testhelper.NewTestContext
+	// Initializes the unexported newTestContextFunc variable to use the test implementation.
+	// This allows us to continue to keep the tests in the separate testing package and keep
+	// the newTestContextFunc variable unexported.
+	newTestContextFunc = testhelper.NewTestContext
 }

--- a/ensuring/internal/testhelper/testhelper.go
+++ b/ensuring/internal/testhelper/testhelper.go
@@ -15,11 +15,11 @@ var (
 
 // NewTestContext is called instead of [testctx.New] and is setup in ../../init_test.go.
 // This shouldn't be used by anything else.
-func NewTestContext(t testctx.T) testctx.Context {
+func NewTestContext(t testctx.T, wrapEnsure testctx.WrapEnsure) testctx.Context {
 	ctx, ok := testContexts[t]
 	if !ok {
 		if allowAnyTestContexts {
-			return testctx.New(t)
+			return testctx.New(t, wrapEnsure)
 		}
 
 		panic("Missing mock test context")

--- a/ensuring/internal/testhelper/testhelper.go
+++ b/ensuring/internal/testhelper/testhelper.go
@@ -2,6 +2,7 @@
 package testhelper
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/JosiahWitt/ensure/internal/testctx"
@@ -11,11 +12,15 @@ import (
 var (
 	testContexts         = map[testctx.T]testctx.Context{}
 	allowAnyTestContexts = false
+
+	checkingWrapEnsure = false // Used to prevent an infinite loop
 )
 
 // NewTestContext is called instead of [testctx.New] and is setup in ../../init_test.go.
 // This shouldn't be used by anything else.
 func NewTestContext(t testctx.T, wrapEnsure testctx.WrapEnsure) testctx.Context {
+	checkWrapEnsure(t, wrapEnsure)
+
 	ctx, ok := testContexts[t]
 	if !ok {
 		if allowAnyTestContexts {
@@ -46,4 +51,19 @@ func AllowAnyTestContexts(t *testing.T) {
 	t.Cleanup(func() {
 		allowAnyTestContexts = false
 	})
+}
+
+func checkWrapEnsure(t testctx.T, wrapEnsure testctx.WrapEnsure) {
+	// Prevent an infinite loop, since NewTestContext will be called by wrapEnsure
+	if checkingWrapEnsure {
+		return
+	}
+
+	checkingWrapEnsure = true
+	defer func() { checkingWrapEnsure = false }()
+
+	ensure := wrapEnsure(t)
+	if ensure == nil || fmt.Sprintf("%T", ensure) != "ensuring.E" {
+		panic(fmt.Sprintf("wrapEnsure doesn't function correctly: %[1]v (%[1]T)", ensure))
+	}
 }

--- a/internal/mocks/mock_testctx/mock_testctx.go
+++ b/internal/mocks/mock_testctx/mock_testctx.go
@@ -239,6 +239,31 @@ func (m *MockContext) EXPECT() *MockContextMockRecorder {
 	return m.recorder
 }
 
+// Ensure mocks Ensure on Context.
+func (m *MockContext) Ensure() interface{} {
+	m.ctrl.T.Helper()
+	inputs := []interface{}{}
+	ret := m.ctrl.Call(m, "Ensure", inputs...)
+	ret0, _ := ret[0].(interface{})
+	return ret0
+}
+
+// Ensure sets up expectations for calls to Ensure.
+// Calling this method multiple times allows expecting multiple calls to Ensure with a variety of parameters.
+//
+// Inputs:
+//
+//	none
+//
+// Outputs:
+//
+//	interface{}
+func (mr *MockContextMockRecorder) Ensure() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	inputs := []interface{}{}
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ensure", reflect.TypeOf((*MockContext)(nil).Ensure), inputs...)
+}
+
 // GoMockController mocks GoMockController on Context.
 func (m *MockContext) GoMockController() *gomock.Controller {
 	m.ctrl.T.Helper()

--- a/internal/plugins/internal/id/id.go
+++ b/internal/plugins/internal/id/id.go
@@ -2,6 +2,8 @@
 package id
 
 const (
+	EnsuringE = "ensuring.E"
+
 	Mocks      = "Mocks"
 	SetupMocks = "SetupMocks"
 	Subject    = "Subject"

--- a/internal/reflectensure/reflectensure.go
+++ b/internal/reflectensure/reflectensure.go
@@ -1,0 +1,15 @@
+// Package reflectensure provides a helper for identifying ensure types via reflection.
+// It is used to avoid import cycles.
+package reflectensure
+
+import "reflect"
+
+const (
+	ensuringPath = "github.com/JosiahWitt/ensure/ensuring"
+	ensuringE    = "E"
+)
+
+// IsEnsuringE returns true only when [ensuring.E] or any of its aliases is provided.
+func IsEnsuringE(t reflect.Type) bool {
+	return t.PkgPath() == ensuringPath && t.Name() == ensuringE
+}

--- a/internal/reflectensure/reflectensure_test.go
+++ b/internal/reflectensure/reflectensure_test.go
@@ -1,0 +1,48 @@
+package reflectensure_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/JosiahWitt/ensure"
+	"github.com/JosiahWitt/ensure/ensurepkg" //lint:ignore SA1019 To ensure compatibility
+	"github.com/JosiahWitt/ensure/ensuring"
+	"github.com/JosiahWitt/ensure/internal/reflectensure"
+)
+
+func TestIsEnsuringE(t *testing.T) {
+	ensure := ensure.New(t)
+
+	ensure.Run("when provided ensuring.E", func(ensure ensuring.E) {
+		t := reflect.TypeOf(ensuring.E(nil))
+		ensure(reflectensure.IsEnsuringE(t)).IsTrue()
+	})
+
+	ensure.Run("when provided pointer to ensuring.E", func(ensure ensuring.E) {
+		e := ensuring.E(nil)
+		t := reflect.TypeOf(&e)
+		ensure(reflectensure.IsEnsuringE(t)).IsFalse()
+	})
+
+	ensure.Run("when provided ensurepkg.Ensure", func(ensure ensuring.E) {
+		t := reflect.TypeOf(ensurepkg.Ensure(nil)) //lint:ignore SA1019 To ensure compatibility
+		ensure(reflectensure.IsEnsuringE(t)).IsTrue()
+	})
+
+	ensure.Run("when provided another type implementing ensuring.E", func(ensure ensuring.E) {
+		type E ensuring.E
+		t := reflect.TypeOf(E(nil))
+		ensure(reflectensure.IsEnsuringE(t)).IsFalse()
+	})
+
+	ensure.Run("when provided another type named E", func(ensure ensuring.E) {
+		type E func(interface{}) *ensuring.Chain
+		t := reflect.TypeOf(E(nil))
+		ensure(reflectensure.IsEnsuringE(t)).IsFalse()
+	})
+
+	ensure.Run("when provided another type in ensuring", func(ensure ensuring.E) {
+		t := reflect.TypeOf(ensuring.Chain{})
+		ensure(reflectensure.IsEnsuringE(t)).IsFalse()
+	})
+}


### PR DESCRIPTION
### Changes
- `SetupMocks` in table driven tests now takes `ensuring.E` as an optional second argument. This provides a correctly scoped `ensure` inside `SetupMocks`.