### PR TITLE
Upgrade from Go 1.25rc1 to 1.25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ["1.20", "1.21", "1.22", "1.23", "1.24", "1.25.0-rc.1"]
+        go-version: ["1.20", "1.21", "1.22", "1.23", "1.24", "1.25"]
         path: [".", "cmd/ensure", "exp/entable"]
         include:
           - path: "."
@@ -16,7 +16,7 @@ jobs:
             flags: cli
           - path: exp/entable
             flags: entable
-          - go-version: "1.25.0-rc.1"
+          - go-version: "1.25"
             godebug: asynctimerchan=0
         exclude:
           - path: cmd/ensure # CLI requires Go 1.21+
@@ -49,12 +49,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ["1.20", "1.21", "1.22", "1.23", "1.24", "1.25.0-rc.1"]
+        go-version: ["1.20", "1.21", "1.22", "1.23", "1.24", "1.25"]
         path: [".", "cmd/ensure", "exp/entable"]
         exclude:
           - path: cmd/ensure # CLI requires Go 1.21+
             go-version: "1.20"
-          - go-version: "1.25.0-rc.1" # TODO: Enable linting on 1.25 when it is no longer a RC
 
     steps:
       - name: Set up Go ${{ matrix.go-version }}
@@ -78,14 +77,13 @@ jobs:
       fail-fast: false
       matrix:
         # Staticcheck requires Go 1.21+
-        go-version: ["1.21", "1.22", "1.23", "1.24", "1.25.0-rc.1"]
+        go-version: ["1.21", "1.22", "1.23", "1.24", "1.25"]
         path: [".", "cmd/ensure", "exp/entable"]
         exclude:
           - path: cmd/ensure # Staticcheck isn't working for CLI on Go 1.21
             go-version: "1.21"
           - path: cmd/ensure # Staticcheck isn't working for CLI on Go 1.22
             go-version: "1.22"
-          - go-version: "1.25.0-rc.1" # TODO: Enable Staticcheck on 1.25 when it is no longer a RC
 
     steps:
       - name: Set up Go ${{ matrix.go-version }}
@@ -110,7 +108,7 @@ jobs:
       fail-fast: false
       matrix:
         # CLI requires Go 1.21+
-        go-version: ["1.21", "1.22", "1.23", "1.24", "1.25.0-rc.1"]
+        go-version: ["1.21", "1.22", "1.23", "1.24", "1.25"]
 
     steps:
       - name: Set up Go ${{ matrix.go-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Lint `${{ matrix.path }}`
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.1.6
+          version: v2.4.0
           working-directory: ${{ matrix.path }}
 
   staticcheck:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,7 @@ linters:
   disable:
     - prealloc
     - wsl
+    - wsl_v5
     - nlreturn
     - wrapcheck
     - godox
@@ -13,6 +14,8 @@ linters:
     - ireturn
     - depguard
     - perfsprint
+    - noinlineerr
+    - embeddedstructfieldcheck
     # We run staticcheck separately:
     - staticcheck
 

--- a/cmd/ensure/.golangci.yml
+++ b/cmd/ensure/.golangci.yml
@@ -5,6 +5,7 @@ linters:
   disable:
     - prealloc
     - wsl
+    - wsl_v5
     - nlreturn
     - wrapcheck
     - godox
@@ -13,6 +14,8 @@ linters:
     - ireturn
     - depguard
     - perfsprint
+    - noinlineerr
+    - embeddedstructfieldcheck
     # We run staticcheck separately:
     - staticcheck
 

--- a/cmd/ensure/internal/fswrite/fswrite_test.go
+++ b/cmd/ensure/internal/fswrite/fswrite_test.go
@@ -43,6 +43,7 @@ func TestListRecursive(t *testing.T) {
 		ensure := ensure.New(t)
 		dirName := t.TempDir()
 
+		//nolint:noctx // TODO: Pass in t.Context() to exec.CommandContext once the minimum Go version is 1.24.
 		cmd := exec.Command("sh", "-c", "mkdir -p abc/xyz qwerty; touch hi.txt abc/hello.txt abc/hello2.txt abc/xyz/here.txt qwerty/ytrewq.txt")
 		cmd.Dir = dirName
 		cmd.Stderr = os.Stderr
@@ -81,6 +82,7 @@ func TestRemoveAll(t *testing.T) {
 	ensure := ensure.New(t)
 	dirName := t.TempDir()
 
+	//nolint:noctx // TODO: Pass in t.Context() to exec.CommandContext once the minimum Go version is 1.24.
 	cmd := exec.Command("sh", "-c", "mkdir -p abc/xyz; touch abc/hello.txt abc/hello2.txt abc/xyz/here.txt")
 	cmd.Dir = dirName
 	cmd.Stderr = os.Stderr

--- a/ensuring/synctest.go
+++ b/ensuring/synctest.go
@@ -21,7 +21,7 @@ func (e E) RunSync(name string, fn func(ensure E)) {
 		t := ctx.T()
 		t.Helper()
 
-		syncable := ctx.(testctx.SyncableContext)
+		syncable := ctx.(testctx.SyncableContext) //nolint:forcetypeassert // In practice, this will always be true.
 		syncable.Sync(func(ctx testctx.Context) {
 			t := ctx.T()
 			t.Helper()
@@ -52,7 +52,7 @@ func (e E) RunTableByIndexSync(table interface{}, fn func(ensure E, i int)) {
 		t := ctx.T()
 		t.Helper()
 
-		syncable := ctx.(testctx.SyncableContext)
+		syncable := ctx.(testctx.SyncableContext) //nolint:forcetypeassert // In practice, this will always be true.
 		syncable.Sync(func(ctx testctx.Context) {
 			t := ctx.T()
 			t.Helper()

--- a/exp/entable/.golangci.yml
+++ b/exp/entable/.golangci.yml
@@ -5,6 +5,7 @@ linters:
   disable:
     - prealloc
     - wsl
+    - wsl_v5
     - nlreturn
     - wrapcheck
     - godox
@@ -13,6 +14,8 @@ linters:
     - ireturn
     - depguard
     - perfsprint
+    - noinlineerr
+    - embeddedstructfieldcheck
     # We run staticcheck separately:
     - staticcheck
 

--- a/internal/testctx/synctest.go
+++ b/internal/testctx/synctest.go
@@ -14,9 +14,10 @@ type syncable interface {
 type baseSync struct{}
 
 func (baseSync) sync(t T, fn func(t *testing.T)) {
-	synctest.Test(t.(*testing.T), fn)
+	synctest.Test(t.(*testing.T), fn) //nolint:forcetypeassert // In practice, this will always be true.
 }
 
+//nolint:gochecknoglobals // This is a non-exported global variable so it can be tested.
 var sync syncable = baseSync{}
 
 // Sync wraps the Go 1.25+ [synctest.Test] function, making it mockable.


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Upgrade Go version from 1.25rc1 to stable 1.25

- Update golangci-lint to v2.4.0 with new linter rules

- Add nolint comments for linter compliance

- Enable linting and staticcheck for Go 1.25


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Go 1.25rc1"] --> B["Go 1.25 stable"]
  C["golangci-lint v2.1.6"] --> D["golangci-lint v2.4.0"]
  E["CI exclusions"] --> F["Full CI support"]
  G["Linter warnings"] --> H["Nolint comments"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Update CI to use stable Go 1.25</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Update Go version from 1.25.0-rc.1 to 1.25 in test matrix<br> <li> Remove exclusions for Go 1.25 in lint and staticcheck jobs<br> <li> Upgrade golangci-lint action version from v2.1.6 to v2.4.0</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/85/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+6/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>.golangci.yml</strong><dd><code>Update linter configuration for v2.4.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.golangci.yml

- Disable new linters: wsl_v5, noinlineerr, embeddedstructfieldcheck


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/85/files#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>.golangci.yml</strong><dd><code>Update CLI linter configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/ensure/.golangci.yml

- Disable new linters: wsl_v5, noinlineerr, embeddedstructfieldcheck


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/85/files#diff-236ce878ce40257922fac6276fd9276c36367ee4b0224ebc0e3bed875dd7af51">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>.golangci.yml</strong><dd><code>Update entable linter configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

exp/entable/.golangci.yml

- Disable new linters: wsl_v5, noinlineerr, embeddedstructfieldcheck


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/85/files#diff-0e2ee1b80217b3eabdfdffac11f20f608656bac31aa62bed37b819a889f71b71">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fswrite_test.go</strong><dd><code>Add nolint comments for context usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/ensure/internal/fswrite/fswrite_test.go

<ul><li>Add nolint:noctx comments for exec.Command usage<br> <li> Include TODO notes about using exec.CommandContext in Go 1.24+</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/85/files#diff-fb0d4c618b2465a634fb21e94ab151c809a61a60f2b526c9c44ca1680553cc0c">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>synctest.go</strong><dd><code>Add nolint comments for type assertions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ensuring/synctest.go

<ul><li>Add nolint:forcetypeassert comments for type assertions<br> <li> Include explanatory comments about type assertion safety</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/85/files#diff-b03c98be78e8000bbb828c5b684757635479a7fbc4100d0513c5cab088ec6c7c">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>synctest.go</strong><dd><code>Add nolint comments for linter compliance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/testctx/synctest.go

<ul><li>Add nolint:forcetypeassert comment for type assertion<br> <li> Add nolint:gochecknoglobals comment for global variable</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/85/files#diff-5e55ece0db81a4c01e4d117779daef23f33030c06454bd9b5f46991c722e37d6">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

