### PR TITLE
Modernize code up through Go 1.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ["1.23", "1.24", "1.25"]
+        go-version: ["1.23", "1.24", "1.25", "1.26"]
         path: [".", "cmd/ensure", "exp/entable"]
         include:
           - path: "."
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ["1.23", "1.24", "1.25"]
+        go-version: ["1.23", "1.24", "1.25", "1.26"]
         path: [".", "cmd/ensure", "exp/entable"]
 
     steps:
@@ -61,7 +61,7 @@ jobs:
       - name: Lint `${{ matrix.path }}`
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.5.0
+          version: v2.9.0
           working-directory: ${{ matrix.path }}
 
   staticcheck:
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ["1.23", "1.24", "1.25"]
+        go-version: ["1.23", "1.24", "1.25", "1.26"]
         path: [".", "cmd/ensure", "exp/entable"]
 
     steps:
@@ -95,7 +95,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ["1.23", "1.24", "1.25"]
+        go-version: ["1.23", "1.24", "1.25", "1.26"]
 
     steps:
       - name: Set up Go ${{ matrix.go-version }}

--- a/cmd/ensure/internal/ensurefile/ensurefile_test.go
+++ b/cmd/ensure/internal/ensurefile/ensurefile_test.go
@@ -218,7 +218,7 @@ func TestPackageString(t *testing.T) {
 	ensure(pkg.String()).Equals("github.com/my/pkg:Iface1,Iface2")
 }
 
-type mapFS map[string]interface{}
+type mapFS map[string]any
 
 func (mapFS mapFS) setupMocks(m *mocks) {
 	m.FS.EXPECT().ReadFile(gomock.Any()).AnyTimes().

--- a/cmd/ensure/internal/ifacereader/fixtures/emptyiface/emptyiface.go
+++ b/cmd/ensure/internal/ifacereader/fixtures/emptyiface/emptyiface.go
@@ -1,3 +1,3 @@
 package emptyiface
 
-type Empty interface{}
+type Empty any

--- a/cmd/ensure/internal/ifacereader/fixtures/externaltypes/example1/example1.go
+++ b/cmd/ensure/internal/ifacereader/fixtures/externaltypes/example1/example1.go
@@ -2,7 +2,7 @@ package example1
 
 import "reflect"
 
-var PackagePath = reflect.TypeOf(String("")).PkgPath()
+var PackagePath = reflect.TypeFor[String]().PkgPath()
 
 type String string
 

--- a/cmd/ensure/internal/ifacereader/fixtures/externaltypes/example2/example2.go
+++ b/cmd/ensure/internal/ifacereader/fixtures/externaltypes/example2/example2.go
@@ -2,7 +2,7 @@ package example2
 
 import "reflect"
 
-var PackagePath = reflect.TypeOf(Float64(0)).PkgPath()
+var PackagePath = reflect.TypeFor[Float64]().PkgPath()
 
 type Float64 float64
 

--- a/cmd/ensure/internal/ifacereader/fixtures/generics/go.mod
+++ b/cmd/ensure/internal/ifacereader/fixtures/generics/go.mod
@@ -1,4 +1,5 @@
-// TODO: Remove this once Go 1.18 is the lowest supported version
+// TODO: Consider refactoring the tests to no longer reference golang.org/x/exp/constraints
+// so we don't need to nest this in a separate module.
 
 module github.com/JosiahWitt/ensure/cmd/ensure/internal/ifacereader/fixtures/generics
 

--- a/cmd/ensure/internal/ifacereader/ifacereader_test.go
+++ b/cmd/ensure/internal/ifacereader/ifacereader_test.go
@@ -1,12 +1,13 @@
 package ifacereader_test
 
 import (
+	"cmp"
 	"fmt"
 	"go/types"
 	"os"
 	"path/filepath"
 	"reflect"
-	"sort"
+	"slices"
 	"testing"
 
 	"github.com/JosiahWitt/ensure"
@@ -505,8 +506,8 @@ func buildTypeTests() []entry {
 		// Go parses interface methods sorted by name, so we sort them to match
 		expectedMethods := make([]*ifacereader.Method, len(fixture.ExpectedMethods))
 		copy(expectedMethods, fixture.ExpectedMethods)
-		sort.Slice(expectedMethods, func(i, j int) bool {
-			return expectedMethods[i].Name < expectedMethods[j].Name
+		slices.SortFunc(expectedMethods, func(a, b *ifacereader.Method) int {
+			return cmp.Compare(a.Name, b.Name)
 		})
 
 		entries = append(entries, entry{
@@ -638,8 +639,8 @@ func buildGenericTests() []entry {
 			},
 
 			ExpectedPackagePaths: []string{
-				"golang.org/x/exp/constraints",
-				"github.com/JosiahWitt/ensure/cmd/ensure/internal/ifacereader/fixtures/generics/externalconstraints/constraints", // TODO: reference this directly once Go 1.18 is the lowest supported version
+				"golang.org/x/exp/constraints", // TODO: remove this once the fixture is no longer dependent on this package
+				"github.com/JosiahWitt/ensure/cmd/ensure/internal/ifacereader/fixtures/generics/externalconstraints/constraints", // TODO: reference this directly once the fixture isn't in a separate nested module
 			},
 
 			ExpectedPackages: []*ifacereader.Package{
@@ -691,9 +692,9 @@ func buildGenericTests() []entry {
 			},
 
 			ExpectedPackagePaths: []string{
-				"golang.org/x/exp/constraints",
-				"github.com/JosiahWitt/ensure/cmd/ensure/internal/ifacereader/fixtures/generics/complexconstraints",              // TODO: reference this directly once Go 1.18 is the lowest supported version
-				"github.com/JosiahWitt/ensure/cmd/ensure/internal/ifacereader/fixtures/generics/complexconstraints/externaltype", // TODO: reference this directly once Go 1.18 is the lowest supported version
+				"golang.org/x/exp/constraints", // TODO: reference this directly once the fixture isn't in a separate nested module
+				"github.com/JosiahWitt/ensure/cmd/ensure/internal/ifacereader/fixtures/generics/complexconstraints",              // TODO: reference this directly once the fixture isn't in a separate nested module
+				"github.com/JosiahWitt/ensure/cmd/ensure/internal/ifacereader/fixtures/generics/complexconstraints/externaltype", // TODO: reference this directly once the fixture isn't in a separate nested module
 			},
 
 			ExpectedPackages: []*ifacereader.Package{

--- a/cmd/ensure/internal/ifacereader/scenarios/base/base.go
+++ b/cmd/ensure/internal/ifacereader/scenarios/base/base.go
@@ -3,7 +3,7 @@ package base
 import "github.com/JosiahWitt/ensure/cmd/ensure/internal/ifacereader"
 
 type ScenarioDetails struct {
-	Fixture interface{}
+	Fixture any
 
 	ExpectedPackagePaths []string
 

--- a/cmd/ensure/internal/ifacereader/scenarios/builtin/builtin.go
+++ b/cmd/ensure/internal/ifacereader/scenarios/builtin/builtin.go
@@ -11,7 +11,7 @@ type Fixture interface {
 	Int(a int) int
 	Float64(a float64) float64
 
-	EmptyInterface(a interface{}) interface{}
+	EmptyInterface(a any) any
 }
 
 var FixtureDetails = &base.ScenarioDetails{
@@ -58,10 +58,10 @@ var FixtureDetails = &base.ScenarioDetails{
 		{
 			Name: "EmptyInterface",
 			Inputs: []*ifacereader.Tuple{
-				{VariableName: "a", Type: "interface{}"},
+				{VariableName: "a", Type: "any"},
 			},
 			Outputs: []*ifacereader.Tuple{
-				{VariableName: "", Type: "interface{}"},
+				{VariableName: "", Type: "any"},
 			},
 		},
 	},

--- a/cmd/ensure/internal/mockgen/scenarios/enhanced_matcher_failures_disabled/pkg1.expected
+++ b/cmd/ensure/internal/mockgen/scenarios/enhanced_matcher_failures_disabled/pkg1.expected
@@ -40,7 +40,7 @@ func (m *MockTransformable) EXPECT() *MockTransformableMockRecorder {
 // TransformString mocks TransformString on Transformable.
 func (m *MockTransformable) TransformString(_prefix string, _strs ...string) (string, error) {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_prefix}
+	inputs := []any{_prefix}
 	for _, variadicInput := range _strs {
 		inputs = append(inputs, variadicInput)
 	}
@@ -62,9 +62,9 @@ func (m *MockTransformable) TransformString(_prefix string, _strs ...string) (st
 //
 //	string
 //	error
-func (mr *MockTransformableMockRecorder) TransformString(_prefix interface{}, _strs ...interface{}) *gomock.Call {
+func (mr *MockTransformableMockRecorder) TransformString(_prefix any, _strs ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{_prefix}
+	inputs := []any{_prefix}
 	for _, variadicInput := range _strs {
 		inputs = append(inputs, variadicInput)
 	}

--- a/cmd/ensure/internal/mockgen/scenarios/generics_multiple_type_params/pkg1.expected
+++ b/cmd/ensure/internal/mockgen/scenarios/generics_multiple_type_params/pkg1.expected
@@ -43,7 +43,7 @@ func (m *MockThingable[T, V]) EXPECT() *MockThingableMockRecorder[T, V] {
 // Identity mocks Identity on Thingable.
 func (m *MockThingable[T, V]) Identity(_in T) T {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_in}
+	inputs := []any{_in}
 	ret := m.ctrl.Call(m, "Identity", inputs...)
 	ret0, _ := ret[0].(T)
 	return ret0
@@ -59,16 +59,16 @@ func (m *MockThingable[T, V]) Identity(_in T) T {
 // Outputs:
 //
 //	T
-func (mr *MockThingableMockRecorder[T, V]) Identity(_in interface{}) *gomock.Call {
+func (mr *MockThingableMockRecorder[T, V]) Identity(_in any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_in)}
+	inputs := []any{wrapMatcher(_in)}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Identity", reflect.TypeOf((*MockThingable[T, V])(nil).Identity), inputs...)
 }
 
 // Transform mocks Transform on Thingable.
 func (m *MockThingable[T, V]) Transform(_in T) V {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_in}
+	inputs := []any{_in}
 	ret := m.ctrl.Call(m, "Transform", inputs...)
 	ret0, _ := ret[0].(V)
 	return ret0
@@ -84,13 +84,13 @@ func (m *MockThingable[T, V]) Transform(_in T) V {
 // Outputs:
 //
 //	V
-func (mr *MockThingableMockRecorder[T, V]) Transform(_in interface{}) *gomock.Call {
+func (mr *MockThingableMockRecorder[T, V]) Transform(_in any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_in)}
+	inputs := []any{wrapMatcher(_in)}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Transform", reflect.TypeOf((*MockThingable[T, V])(nil).Transform), inputs...)
 }
 
-func wrapMatcher(input interface{}) gomock.Matcher {
+func wrapMatcher(input any) gomock.Matcher {
 	if matcher, ok := input.(gomock.Matcher); ok {
 		return matcher
 	}
@@ -110,7 +110,7 @@ func wrapMatcher(input interface{}) gomock.Matcher {
 	)
 
 	return gomock.GotFormatterAdapter(
-		gomock.GotFormatterFunc(func(got interface{}) string {
+		gomock.GotFormatterFunc(func(got any) string {
 			return pretty.Sprint(got)
 		}),
 		matcher,

--- a/cmd/ensure/internal/mockgen/scenarios/generics_single_type_param/pkg1.expected
+++ b/cmd/ensure/internal/mockgen/scenarios/generics_single_type_param/pkg1.expected
@@ -41,7 +41,7 @@ func (m *MockIdentifier[T]) EXPECT() *MockIdentifierMockRecorder[T] {
 // Identity mocks Identity on Identifier.
 func (m *MockIdentifier[T]) Identity(_in T) T {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_in}
+	inputs := []any{_in}
 	ret := m.ctrl.Call(m, "Identity", inputs...)
 	ret0, _ := ret[0].(T)
 	return ret0
@@ -57,13 +57,13 @@ func (m *MockIdentifier[T]) Identity(_in T) T {
 // Outputs:
 //
 //	T
-func (mr *MockIdentifierMockRecorder[T]) Identity(_in interface{}) *gomock.Call {
+func (mr *MockIdentifierMockRecorder[T]) Identity(_in any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_in)}
+	inputs := []any{wrapMatcher(_in)}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Identity", reflect.TypeOf((*MockIdentifier[T])(nil).Identity), inputs...)
 }
 
-func wrapMatcher(input interface{}) gomock.Matcher {
+func wrapMatcher(input any) gomock.Matcher {
 	if matcher, ok := input.(gomock.Matcher); ok {
 		return matcher
 	}
@@ -83,7 +83,7 @@ func wrapMatcher(input interface{}) gomock.Matcher {
 	)
 
 	return gomock.GotFormatterAdapter(
-		gomock.GotFormatterFunc(func(got interface{}) string {
+		gomock.GotFormatterFunc(func(got any) string {
 			return pretty.Sprint(got)
 		}),
 		matcher,

--- a/cmd/ensure/internal/mockgen/scenarios/multiple_interfaces/pkg1.expected
+++ b/cmd/ensure/internal/mockgen/scenarios/multiple_interfaces/pkg1.expected
@@ -41,7 +41,7 @@ func (m *MockStringTransformable) EXPECT() *MockStringTransformableMockRecorder 
 // TransformString mocks TransformString on StringTransformable.
 func (m *MockStringTransformable) TransformString(_prefix string, _str string) (string, error) {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_prefix, _str}
+	inputs := []any{_prefix, _str}
 	ret := m.ctrl.Call(m, "TransformString", inputs...)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -60,9 +60,9 @@ func (m *MockStringTransformable) TransformString(_prefix string, _str string) (
 //
 //	string
 //	error
-func (mr *MockStringTransformableMockRecorder) TransformString(_prefix interface{}, _str interface{}) *gomock.Call {
+func (mr *MockStringTransformableMockRecorder) TransformString(_prefix any, _str any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_prefix), wrapMatcher(_str)}
+	inputs := []any{wrapMatcher(_prefix), wrapMatcher(_str)}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransformString", reflect.TypeOf((*MockStringTransformable)(nil).TransformString), inputs...)
 }
 
@@ -97,7 +97,7 @@ func (m *MockNumberTransformable) EXPECT() *MockNumberTransformableMockRecorder 
 // TransformInt mocks TransformInt on NumberTransformable.
 func (m *MockNumberTransformable) TransformInt(_i int) int {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_i}
+	inputs := []any{_i}
 	ret := m.ctrl.Call(m, "TransformInt", inputs...)
 	ret0, _ := ret[0].(int)
 	return ret0
@@ -113,16 +113,16 @@ func (m *MockNumberTransformable) TransformInt(_i int) int {
 // Outputs:
 //
 //	int
-func (mr *MockNumberTransformableMockRecorder) TransformInt(_i interface{}) *gomock.Call {
+func (mr *MockNumberTransformableMockRecorder) TransformInt(_i any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_i)}
+	inputs := []any{wrapMatcher(_i)}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransformInt", reflect.TypeOf((*MockNumberTransformable)(nil).TransformInt), inputs...)
 }
 
 // TransformFloat64 mocks TransformFloat64 on NumberTransformable.
 func (m *MockNumberTransformable) TransformFloat64(_f float64) float64 {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_f}
+	inputs := []any{_f}
 	ret := m.ctrl.Call(m, "TransformFloat64", inputs...)
 	ret0, _ := ret[0].(float64)
 	return ret0
@@ -138,13 +138,13 @@ func (m *MockNumberTransformable) TransformFloat64(_f float64) float64 {
 // Outputs:
 //
 //	float64
-func (mr *MockNumberTransformableMockRecorder) TransformFloat64(_f interface{}) *gomock.Call {
+func (mr *MockNumberTransformableMockRecorder) TransformFloat64(_f any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_f)}
+	inputs := []any{wrapMatcher(_f)}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransformFloat64", reflect.TypeOf((*MockNumberTransformable)(nil).TransformFloat64), inputs...)
 }
 
-func wrapMatcher(input interface{}) gomock.Matcher {
+func wrapMatcher(input any) gomock.Matcher {
 	if matcher, ok := input.(gomock.Matcher); ok {
 		return matcher
 	}
@@ -164,7 +164,7 @@ func wrapMatcher(input interface{}) gomock.Matcher {
 	)
 
 	return gomock.GotFormatterAdapter(
-		gomock.GotFormatterFunc(func(got interface{}) string {
+		gomock.GotFormatterFunc(func(got any) string {
 			return pretty.Sprint(got)
 		}),
 		matcher,

--- a/cmd/ensure/internal/mockgen/scenarios/single_interface_multiple_methods/pkg1.expected
+++ b/cmd/ensure/internal/mockgen/scenarios/single_interface_multiple_methods/pkg1.expected
@@ -41,7 +41,7 @@ func (m *MockTransformable) EXPECT() *MockTransformableMockRecorder {
 // TransformString mocks TransformString on Transformable.
 func (m *MockTransformable) TransformString(_prefix string, _str string) (string, error) {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_prefix, _str}
+	inputs := []any{_prefix, _str}
 	ret := m.ctrl.Call(m, "TransformString", inputs...)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -60,16 +60,16 @@ func (m *MockTransformable) TransformString(_prefix string, _str string) (string
 //
 //	string
 //	error
-func (mr *MockTransformableMockRecorder) TransformString(_prefix interface{}, _str interface{}) *gomock.Call {
+func (mr *MockTransformableMockRecorder) TransformString(_prefix any, _str any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_prefix), wrapMatcher(_str)}
+	inputs := []any{wrapMatcher(_prefix), wrapMatcher(_str)}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransformString", reflect.TypeOf((*MockTransformable)(nil).TransformString), inputs...)
 }
 
 // TransformFloat64 mocks TransformFloat64 on Transformable.
 func (m *MockTransformable) TransformFloat64(_f float64) float64 {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_f}
+	inputs := []any{_f}
 	ret := m.ctrl.Call(m, "TransformFloat64", inputs...)
 	ret0, _ := ret[0].(float64)
 	return ret0
@@ -85,13 +85,13 @@ func (m *MockTransformable) TransformFloat64(_f float64) float64 {
 // Outputs:
 //
 //	float64
-func (mr *MockTransformableMockRecorder) TransformFloat64(_f interface{}) *gomock.Call {
+func (mr *MockTransformableMockRecorder) TransformFloat64(_f any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_f)}
+	inputs := []any{wrapMatcher(_f)}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransformFloat64", reflect.TypeOf((*MockTransformable)(nil).TransformFloat64), inputs...)
 }
 
-func wrapMatcher(input interface{}) gomock.Matcher {
+func wrapMatcher(input any) gomock.Matcher {
 	if matcher, ok := input.(gomock.Matcher); ok {
 		return matcher
 	}
@@ -111,7 +111,7 @@ func wrapMatcher(input interface{}) gomock.Matcher {
 	)
 
 	return gomock.GotFormatterAdapter(
-		gomock.GotFormatterFunc(func(got interface{}) string {
+		gomock.GotFormatterFunc(func(got any) string {
 			return pretty.Sprint(got)
 		}),
 		matcher,

--- a/cmd/ensure/internal/mockgen/scenarios/single_method_external_imports/pkg1.expected
+++ b/cmd/ensure/internal/mockgen/scenarios/single_method_external_imports/pkg1.expected
@@ -43,7 +43,7 @@ func (m *MockTransformable) EXPECT() *MockTransformableMockRecorder {
 // Transform mocks Transform on Transformable.
 func (m *MockTransformable) Transform(_user *external1.User, _message *external2.Message) external1.String {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_user, _message}
+	inputs := []any{_user, _message}
 	ret := m.ctrl.Call(m, "Transform", inputs...)
 	ret0, _ := ret[0].(external1.String)
 	return ret0
@@ -60,13 +60,13 @@ func (m *MockTransformable) Transform(_user *external1.User, _message *external2
 // Outputs:
 //
 //	external1.String
-func (mr *MockTransformableMockRecorder) Transform(_user interface{}, _message interface{}) *gomock.Call {
+func (mr *MockTransformableMockRecorder) Transform(_user any, _message any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_user), wrapMatcher(_message)}
+	inputs := []any{wrapMatcher(_user), wrapMatcher(_message)}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Transform", reflect.TypeOf((*MockTransformable)(nil).Transform), inputs...)
 }
 
-func wrapMatcher(input interface{}) gomock.Matcher {
+func wrapMatcher(input any) gomock.Matcher {
 	if matcher, ok := input.(gomock.Matcher); ok {
 		return matcher
 	}
@@ -86,7 +86,7 @@ func wrapMatcher(input interface{}) gomock.Matcher {
 	)
 
 	return gomock.GotFormatterAdapter(
-		gomock.GotFormatterFunc(func(got interface{}) string {
+		gomock.GotFormatterFunc(func(got any) string {
 			return pretty.Sprint(got)
 		}),
 		matcher,

--- a/cmd/ensure/internal/mockgen/scenarios/single_method_external_imports_clash_with_required/pkg1.expected
+++ b/cmd/ensure/internal/mockgen/scenarios/single_method_external_imports_clash_with_required/pkg1.expected
@@ -43,7 +43,7 @@ func (m *MockDoable) EXPECT() *MockDoableMockRecorder {
 // Do mocks Do on Doable.
 func (m *MockDoable) Do(_thing *reflect.Thing, _other *gomock.Other) {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_thing, _other}
+	inputs := []any{_thing, _other}
 	ret := m.ctrl.Call(m, "Do", inputs...)
 	var _ = ret // Unused, since there are no returns
 	return
@@ -60,13 +60,13 @@ func (m *MockDoable) Do(_thing *reflect.Thing, _other *gomock.Other) {
 // Outputs:
 //
 //	none
-func (mr *MockDoableMockRecorder) Do(_thing interface{}, _other interface{}) *gomock2.Call {
+func (mr *MockDoableMockRecorder) Do(_thing any, _other any) *gomock2.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_thing), wrapMatcher(_other)}
+	inputs := []any{wrapMatcher(_thing), wrapMatcher(_other)}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Do", reflect2.TypeOf((*MockDoable)(nil).Do), inputs...)
 }
 
-func wrapMatcher(input interface{}) gomock2.Matcher {
+func wrapMatcher(input any) gomock2.Matcher {
 	if matcher, ok := input.(gomock2.Matcher); ok {
 		return matcher
 	}
@@ -86,7 +86,7 @@ func wrapMatcher(input interface{}) gomock2.Matcher {
 	)
 
 	return gomock2.GotFormatterAdapter(
-		gomock2.GotFormatterFunc(func(got interface{}) string {
+		gomock2.GotFormatterFunc(func(got any) string {
 			return pretty.Sprint(got)
 		}),
 		matcher,

--- a/cmd/ensure/internal/mockgen/scenarios/single_method_external_imports_with_aliases/pkg1.expected
+++ b/cmd/ensure/internal/mockgen/scenarios/single_method_external_imports_with_aliases/pkg1.expected
@@ -43,7 +43,7 @@ func (m *MockTransformable) EXPECT() *MockTransformableMockRecorder {
 // Transform mocks Transform on Transformable.
 func (m *MockTransformable) Transform(_user *models.User, _message *models2.Message) models.String {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_user, _message}
+	inputs := []any{_user, _message}
 	ret := m.ctrl.Call(m, "Transform", inputs...)
 	ret0, _ := ret[0].(models.String)
 	return ret0
@@ -60,13 +60,13 @@ func (m *MockTransformable) Transform(_user *models.User, _message *models2.Mess
 // Outputs:
 //
 //	models.String
-func (mr *MockTransformableMockRecorder) Transform(_user interface{}, _message interface{}) *gomock.Call {
+func (mr *MockTransformableMockRecorder) Transform(_user any, _message any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_user), wrapMatcher(_message)}
+	inputs := []any{wrapMatcher(_user), wrapMatcher(_message)}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Transform", reflect.TypeOf((*MockTransformable)(nil).Transform), inputs...)
 }
 
-func wrapMatcher(input interface{}) gomock.Matcher {
+func wrapMatcher(input any) gomock.Matcher {
 	if matcher, ok := input.(gomock.Matcher); ok {
 		return matcher
 	}
@@ -86,7 +86,7 @@ func wrapMatcher(input interface{}) gomock.Matcher {
 	)
 
 	return gomock.GotFormatterAdapter(
-		gomock.GotFormatterFunc(func(got interface{}) string {
+		gomock.GotFormatterFunc(func(got any) string {
 			return pretty.Sprint(got)
 		}),
 		matcher,

--- a/cmd/ensure/internal/mockgen/scenarios/single_method_multiple_params/pkg1.expected
+++ b/cmd/ensure/internal/mockgen/scenarios/single_method_multiple_params/pkg1.expected
@@ -41,7 +41,7 @@ func (m *MockTransformable) EXPECT() *MockTransformableMockRecorder {
 // TransformString mocks TransformString on Transformable.
 func (m *MockTransformable) TransformString(_prefix string, _str string) (string, error) {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_prefix, _str}
+	inputs := []any{_prefix, _str}
 	ret := m.ctrl.Call(m, "TransformString", inputs...)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -60,13 +60,13 @@ func (m *MockTransformable) TransformString(_prefix string, _str string) (string
 //
 //	string
 //	error
-func (mr *MockTransformableMockRecorder) TransformString(_prefix interface{}, _str interface{}) *gomock.Call {
+func (mr *MockTransformableMockRecorder) TransformString(_prefix any, _str any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_prefix), wrapMatcher(_str)}
+	inputs := []any{wrapMatcher(_prefix), wrapMatcher(_str)}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransformString", reflect.TypeOf((*MockTransformable)(nil).TransformString), inputs...)
 }
 
-func wrapMatcher(input interface{}) gomock.Matcher {
+func wrapMatcher(input any) gomock.Matcher {
 	if matcher, ok := input.(gomock.Matcher); ok {
 		return matcher
 	}
@@ -86,7 +86,7 @@ func wrapMatcher(input interface{}) gomock.Matcher {
 	)
 
 	return gomock.GotFormatterAdapter(
-		gomock.GotFormatterFunc(func(got interface{}) string {
+		gomock.GotFormatterFunc(func(got any) string {
 			return pretty.Sprint(got)
 		}),
 		matcher,

--- a/cmd/ensure/internal/mockgen/scenarios/single_method_named_outputs/pkg1.expected
+++ b/cmd/ensure/internal/mockgen/scenarios/single_method_named_outputs/pkg1.expected
@@ -41,7 +41,7 @@ func (m *MockTransformable) EXPECT() *MockTransformableMockRecorder {
 // TransformString mocks TransformString on Transformable.
 func (m *MockTransformable) TransformString(_prefix string, _str string) (_transformedStr string, _err error) {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_prefix, _str}
+	inputs := []any{_prefix, _str}
 	ret := m.ctrl.Call(m, "TransformString", inputs...)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -60,13 +60,13 @@ func (m *MockTransformable) TransformString(_prefix string, _str string) (_trans
 //
 //	transformedStr string
 //	err error
-func (mr *MockTransformableMockRecorder) TransformString(_prefix interface{}, _str interface{}) *gomock.Call {
+func (mr *MockTransformableMockRecorder) TransformString(_prefix any, _str any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_prefix), wrapMatcher(_str)}
+	inputs := []any{wrapMatcher(_prefix), wrapMatcher(_str)}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransformString", reflect.TypeOf((*MockTransformable)(nil).TransformString), inputs...)
 }
 
-func wrapMatcher(input interface{}) gomock.Matcher {
+func wrapMatcher(input any) gomock.Matcher {
 	if matcher, ok := input.(gomock.Matcher); ok {
 		return matcher
 	}
@@ -86,7 +86,7 @@ func wrapMatcher(input interface{}) gomock.Matcher {
 	)
 
 	return gomock.GotFormatterAdapter(
-		gomock.GotFormatterFunc(func(got interface{}) string {
+		gomock.GotFormatterFunc(func(got any) string {
 			return pretty.Sprint(got)
 		}),
 		matcher,

--- a/cmd/ensure/internal/mockgen/scenarios/single_method_no_imports/pkg1.expected
+++ b/cmd/ensure/internal/mockgen/scenarios/single_method_no_imports/pkg1.expected
@@ -41,7 +41,7 @@ func (m *MockTransformable) EXPECT() *MockTransformableMockRecorder {
 // TransformString mocks TransformString on Transformable.
 func (m *MockTransformable) TransformString(_str string) string {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_str}
+	inputs := []any{_str}
 	ret := m.ctrl.Call(m, "TransformString", inputs...)
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -57,13 +57,13 @@ func (m *MockTransformable) TransformString(_str string) string {
 // Outputs:
 //
 //	string
-func (mr *MockTransformableMockRecorder) TransformString(_str interface{}) *gomock.Call {
+func (mr *MockTransformableMockRecorder) TransformString(_str any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_str)}
+	inputs := []any{wrapMatcher(_str)}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransformString", reflect.TypeOf((*MockTransformable)(nil).TransformString), inputs...)
 }
 
-func wrapMatcher(input interface{}) gomock.Matcher {
+func wrapMatcher(input any) gomock.Matcher {
 	if matcher, ok := input.(gomock.Matcher); ok {
 		return matcher
 	}
@@ -83,7 +83,7 @@ func wrapMatcher(input interface{}) gomock.Matcher {
 	)
 
 	return gomock.GotFormatterAdapter(
-		gomock.GotFormatterFunc(func(got interface{}) string {
+		gomock.GotFormatterFunc(func(got any) string {
 			return pretty.Sprint(got)
 		}),
 		matcher,

--- a/cmd/ensure/internal/mockgen/scenarios/single_method_no_params/noop.expected
+++ b/cmd/ensure/internal/mockgen/scenarios/single_method_no_params/noop.expected
@@ -41,7 +41,7 @@ func (m *MockNoopable) EXPECT() *MockNoopableMockRecorder {
 // Noop mocks Noop on Noopable.
 func (m *MockNoopable) Noop() {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{}
+	inputs := []any{}
 	ret := m.ctrl.Call(m, "Noop", inputs...)
 	var _ = ret // Unused, since there are no returns
 	return
@@ -59,11 +59,11 @@ func (m *MockNoopable) Noop() {
 //	none
 func (mr *MockNoopableMockRecorder) Noop() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{}
+	inputs := []any{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Noop", reflect.TypeOf((*MockNoopable)(nil).Noop), inputs...)
 }
 
-func wrapMatcher(input interface{}) gomock.Matcher {
+func wrapMatcher(input any) gomock.Matcher {
 	if matcher, ok := input.(gomock.Matcher); ok {
 		return matcher
 	}
@@ -83,7 +83,7 @@ func wrapMatcher(input interface{}) gomock.Matcher {
 	)
 
 	return gomock.GotFormatterAdapter(
-		gomock.GotFormatterFunc(func(got interface{}) string {
+		gomock.GotFormatterFunc(func(got any) string {
 			return pretty.Sprint(got)
 		}),
 		matcher,

--- a/cmd/ensure/internal/mockgen/scenarios/single_method_unnamed_inputs/pkg1.expected
+++ b/cmd/ensure/internal/mockgen/scenarios/single_method_unnamed_inputs/pkg1.expected
@@ -41,7 +41,7 @@ func (m *MockTransformable) EXPECT() *MockTransformableMockRecorder {
 // TransformString mocks TransformString on Transformable.
 func (m *MockTransformable) TransformString(_arg0 string, _arg1 string) (string, error) {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_arg0, _arg1}
+	inputs := []any{_arg0, _arg1}
 	ret := m.ctrl.Call(m, "TransformString", inputs...)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -60,13 +60,13 @@ func (m *MockTransformable) TransformString(_arg0 string, _arg1 string) (string,
 //
 //	string
 //	error
-func (mr *MockTransformableMockRecorder) TransformString(_arg0 interface{}, _arg1 interface{}) *gomock.Call {
+func (mr *MockTransformableMockRecorder) TransformString(_arg0 any, _arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_arg0), wrapMatcher(_arg1)}
+	inputs := []any{wrapMatcher(_arg0), wrapMatcher(_arg1)}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransformString", reflect.TypeOf((*MockTransformable)(nil).TransformString), inputs...)
 }
 
-func wrapMatcher(input interface{}) gomock.Matcher {
+func wrapMatcher(input any) gomock.Matcher {
 	if matcher, ok := input.(gomock.Matcher); ok {
 		return matcher
 	}
@@ -86,7 +86,7 @@ func wrapMatcher(input interface{}) gomock.Matcher {
 	)
 
 	return gomock.GotFormatterAdapter(
-		gomock.GotFormatterFunc(func(got interface{}) string {
+		gomock.GotFormatterFunc(func(got any) string {
 			return pretty.Sprint(got)
 		}),
 		matcher,

--- a/cmd/ensure/internal/mockgen/scenarios/single_method_variadic_input/pkg1.expected
+++ b/cmd/ensure/internal/mockgen/scenarios/single_method_variadic_input/pkg1.expected
@@ -41,7 +41,7 @@ func (m *MockTransformable) EXPECT() *MockTransformableMockRecorder {
 // TransformString mocks TransformString on Transformable.
 func (m *MockTransformable) TransformString(_prefix string, _strs ...string) (string, error) {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_prefix}
+	inputs := []any{_prefix}
 	for _, variadicInput := range _strs {
 		inputs = append(inputs, variadicInput)
 	}
@@ -63,16 +63,16 @@ func (m *MockTransformable) TransformString(_prefix string, _strs ...string) (st
 //
 //	string
 //	error
-func (mr *MockTransformableMockRecorder) TransformString(_prefix interface{}, _strs ...interface{}) *gomock.Call {
+func (mr *MockTransformableMockRecorder) TransformString(_prefix any, _strs ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_prefix)}
+	inputs := []any{wrapMatcher(_prefix)}
 	for _, variadicInput := range _strs {
 		inputs = append(inputs, wrapMatcher(variadicInput))
 	}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransformString", reflect.TypeOf((*MockTransformable)(nil).TransformString), inputs...)
 }
 
-func wrapMatcher(input interface{}) gomock.Matcher {
+func wrapMatcher(input any) gomock.Matcher {
 	if matcher, ok := input.(gomock.Matcher); ok {
 		return matcher
 	}
@@ -92,7 +92,7 @@ func wrapMatcher(input interface{}) gomock.Matcher {
 	)
 
 	return gomock.GotFormatterAdapter(
-		gomock.GotFormatterFunc(func(got interface{}) string {
+		gomock.GotFormatterFunc(func(got any) string {
 			return pretty.Sprint(got)
 		}),
 		matcher,

--- a/cmd/ensure/internal/mockgen/template.go
+++ b/cmd/ensure/internal/mockgen/template.go
@@ -98,7 +98,7 @@ func (mr *{{buildMockRecorderStructName $iface}}) {{$method.Name}}({{buildMockIn
 {{end -}}
 {{end -}}
 {{if $params.EnableEnhancedMatcherFailures}}
-func wrapMatcher(input interface{}) {{$params.GoMockPackageName}}.Matcher {
+func wrapMatcher(input any) {{$params.GoMockPackageName}}.Matcher {
 	if matcher, ok := input.({{$params.GoMockPackageName}}.Matcher); ok {
 		return matcher
 	}
@@ -118,7 +118,7 @@ func wrapMatcher(input interface{}) {{$params.GoMockPackageName}}.Matcher {
 	)
 
 	return {{$params.GoMockPackageName}}.GotFormatterAdapter(
-		{{$params.GoMockPackageName}}.GotFormatterFunc(func(got interface{}) string {
+		{{$params.GoMockPackageName}}.GotFormatterFunc(func(got any) string {
 			return {{$params.PrettyPackageName}}.Sprint(got)
 		}),
 		matcher,
@@ -187,9 +187,9 @@ func templateFuncBuildMockInputSignature(inputs []*ifacereader.Tuple) string {
 
 	builtInputs := make([]string, 0, len(inputs))
 	for _, input := range preprocessParams(inputs, false) {
-		inputType := "interface{}"
+		inputType := "any"
 		if input.Variadic {
-			inputType = "...interface{}"
+			inputType = "...any"
 		}
 
 		builtInputs = append(builtInputs, input.VariableName+" "+inputType)
@@ -212,7 +212,7 @@ func templateFuncBuildInputsSlice(params *templateParams, inputs []*ifacereader.
 		nonVariadicVariables = append(nonVariadicVariables, params.maybeWrapVariable(canWrap, input.VariableName))
 	}
 
-	builtInputs := fmt.Sprintf("inputs := []interface{}{%s}", strings.Join(nonVariadicVariables, ", "))
+	builtInputs := fmt.Sprintf("inputs := []any{%s}", strings.Join(nonVariadicVariables, ", "))
 
 	if variadicVariable != "" {
 		builtInputs += fmt.Sprintf(

--- a/cmd/ensure/internal/mocks/io/mock_fs/mock_fs.go
+++ b/cmd/ensure/internal/mocks/io/mock_fs/mock_fs.go
@@ -42,7 +42,7 @@ func (m *MockReadFileFS) EXPECT() *MockReadFileFSMockRecorder {
 // Open mocks Open on ReadFileFS.
 func (m *MockReadFileFS) Open(_name string) (fs.File, error) {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_name}
+	inputs := []any{_name}
 	ret := m.ctrl.Call(m, "Open", inputs...)
 	ret0, _ := ret[0].(fs.File)
 	ret1, _ := ret[1].(error)
@@ -60,16 +60,16 @@ func (m *MockReadFileFS) Open(_name string) (fs.File, error) {
 //
 //	fs.File
 //	error
-func (mr *MockReadFileFSMockRecorder) Open(_name interface{}) *gomock.Call {
+func (mr *MockReadFileFSMockRecorder) Open(_name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_name)}
+	inputs := []any{wrapMatcher(_name)}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Open", reflect.TypeOf((*MockReadFileFS)(nil).Open), inputs...)
 }
 
 // ReadFile mocks ReadFile on ReadFileFS.
 func (m *MockReadFileFS) ReadFile(_name string) ([]byte, error) {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_name}
+	inputs := []any{_name}
 	ret := m.ctrl.Call(m, "ReadFile", inputs...)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
@@ -87,13 +87,13 @@ func (m *MockReadFileFS) ReadFile(_name string) ([]byte, error) {
 //
 //	[]byte
 //	error
-func (mr *MockReadFileFSMockRecorder) ReadFile(_name interface{}) *gomock.Call {
+func (mr *MockReadFileFSMockRecorder) ReadFile(_name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_name)}
+	inputs := []any{wrapMatcher(_name)}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadFile", reflect.TypeOf((*MockReadFileFS)(nil).ReadFile), inputs...)
 }
 
-func wrapMatcher(input interface{}) gomock.Matcher {
+func wrapMatcher(input any) gomock.Matcher {
 	if matcher, ok := input.(gomock.Matcher); ok {
 		return matcher
 	}
@@ -113,7 +113,7 @@ func wrapMatcher(input interface{}) gomock.Matcher {
 	)
 
 	return gomock.GotFormatterAdapter(
-		gomock.GotFormatterFunc(func(got interface{}) string {
+		gomock.GotFormatterFunc(func(got any) string {
 			return pretty.Sprint(got)
 		}),
 		matcher,

--- a/cmd/ensure/internal/mocks/mock_ensurefile/mock_ensurefile.go
+++ b/cmd/ensure/internal/mocks/mock_ensurefile/mock_ensurefile.go
@@ -42,7 +42,7 @@ func (m *MockLoaderIface) EXPECT() *MockLoaderIfaceMockRecorder {
 // LoadConfig mocks LoadConfig on LoaderIface.
 func (m *MockLoaderIface) LoadConfig(_pwd string) (*ensurefile.Config, error) {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_pwd}
+	inputs := []any{_pwd}
 	ret := m.ctrl.Call(m, "LoadConfig", inputs...)
 	ret0, _ := ret[0].(*ensurefile.Config)
 	ret1, _ := ret[1].(error)
@@ -60,13 +60,13 @@ func (m *MockLoaderIface) LoadConfig(_pwd string) (*ensurefile.Config, error) {
 //
 //	*ensurefile.Config
 //	error
-func (mr *MockLoaderIfaceMockRecorder) LoadConfig(_pwd interface{}) *gomock.Call {
+func (mr *MockLoaderIfaceMockRecorder) LoadConfig(_pwd any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_pwd)}
+	inputs := []any{wrapMatcher(_pwd)}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadConfig", reflect.TypeOf((*MockLoaderIface)(nil).LoadConfig), inputs...)
 }
 
-func wrapMatcher(input interface{}) gomock.Matcher {
+func wrapMatcher(input any) gomock.Matcher {
 	if matcher, ok := input.(gomock.Matcher); ok {
 		return matcher
 	}
@@ -86,7 +86,7 @@ func wrapMatcher(input interface{}) gomock.Matcher {
 	)
 
 	return gomock.GotFormatterAdapter(
-		gomock.GotFormatterFunc(func(got interface{}) string {
+		gomock.GotFormatterFunc(func(got any) string {
 			return pretty.Sprint(got)
 		}),
 		matcher,

--- a/cmd/ensure/internal/mocks/mock_fswrite/mock_fswrite.go
+++ b/cmd/ensure/internal/mocks/mock_fswrite/mock_fswrite.go
@@ -42,7 +42,7 @@ func (m *MockWritable) EXPECT() *MockWritableMockRecorder {
 // ListRecursive mocks ListRecursive on Writable.
 func (m *MockWritable) ListRecursive(_dir string) ([]string, error) {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_dir}
+	inputs := []any{_dir}
 	ret := m.ctrl.Call(m, "ListRecursive", inputs...)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -60,16 +60,16 @@ func (m *MockWritable) ListRecursive(_dir string) ([]string, error) {
 //
 //	[]string
 //	error
-func (mr *MockWritableMockRecorder) ListRecursive(_dir interface{}) *gomock.Call {
+func (mr *MockWritableMockRecorder) ListRecursive(_dir any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_dir)}
+	inputs := []any{wrapMatcher(_dir)}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRecursive", reflect.TypeOf((*MockWritable)(nil).ListRecursive), inputs...)
 }
 
 // MkdirAll mocks MkdirAll on Writable.
 func (m *MockWritable) MkdirAll(_path string, _perm os.FileMode) error {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_path, _perm}
+	inputs := []any{_path, _perm}
 	ret := m.ctrl.Call(m, "MkdirAll", inputs...)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -86,16 +86,16 @@ func (m *MockWritable) MkdirAll(_path string, _perm os.FileMode) error {
 // Outputs:
 //
 //	error
-func (mr *MockWritableMockRecorder) MkdirAll(_path interface{}, _perm interface{}) *gomock.Call {
+func (mr *MockWritableMockRecorder) MkdirAll(_path any, _perm any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_path), wrapMatcher(_perm)}
+	inputs := []any{wrapMatcher(_path), wrapMatcher(_perm)}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MkdirAll", reflect.TypeOf((*MockWritable)(nil).MkdirAll), inputs...)
 }
 
 // RemoveAll mocks RemoveAll on Writable.
 func (m *MockWritable) RemoveAll(_paths string) error {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_paths}
+	inputs := []any{_paths}
 	ret := m.ctrl.Call(m, "RemoveAll", inputs...)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -111,16 +111,16 @@ func (m *MockWritable) RemoveAll(_paths string) error {
 // Outputs:
 //
 //	error
-func (mr *MockWritableMockRecorder) RemoveAll(_paths interface{}) *gomock.Call {
+func (mr *MockWritableMockRecorder) RemoveAll(_paths any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_paths)}
+	inputs := []any{wrapMatcher(_paths)}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveAll", reflect.TypeOf((*MockWritable)(nil).RemoveAll), inputs...)
 }
 
 // WriteFile mocks WriteFile on Writable.
 func (m *MockWritable) WriteFile(_filename string, _data string, _perm os.FileMode) error {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_filename, _data, _perm}
+	inputs := []any{_filename, _data, _perm}
 	ret := m.ctrl.Call(m, "WriteFile", inputs...)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -138,13 +138,13 @@ func (m *MockWritable) WriteFile(_filename string, _data string, _perm os.FileMo
 // Outputs:
 //
 //	error
-func (mr *MockWritableMockRecorder) WriteFile(_filename interface{}, _data interface{}, _perm interface{}) *gomock.Call {
+func (mr *MockWritableMockRecorder) WriteFile(_filename any, _data any, _perm any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_filename), wrapMatcher(_data), wrapMatcher(_perm)}
+	inputs := []any{wrapMatcher(_filename), wrapMatcher(_data), wrapMatcher(_perm)}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteFile", reflect.TypeOf((*MockWritable)(nil).WriteFile), inputs...)
 }
 
-func wrapMatcher(input interface{}) gomock.Matcher {
+func wrapMatcher(input any) gomock.Matcher {
 	if matcher, ok := input.(gomock.Matcher); ok {
 		return matcher
 	}
@@ -164,7 +164,7 @@ func wrapMatcher(input interface{}) gomock.Matcher {
 	)
 
 	return gomock.GotFormatterAdapter(
-		gomock.GotFormatterFunc(func(got interface{}) string {
+		gomock.GotFormatterFunc(func(got any) string {
 			return pretty.Sprint(got)
 		}),
 		matcher,

--- a/cmd/ensure/internal/mocks/mock_ifacereader/mock_ifacereader.go
+++ b/cmd/ensure/internal/mocks/mock_ifacereader/mock_ifacereader.go
@@ -42,7 +42,7 @@ func (m *MockReadable) EXPECT() *MockReadableMockRecorder {
 // ReadPackages mocks ReadPackages on Readable.
 func (m *MockReadable) ReadPackages(_pkgDetails []*ifacereader.PackageDetails, _pkgNameGen ifacereader.PackageNameGenerator) ([]*ifacereader.Package, error) {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_pkgDetails, _pkgNameGen}
+	inputs := []any{_pkgDetails, _pkgNameGen}
 	ret := m.ctrl.Call(m, "ReadPackages", inputs...)
 	ret0, _ := ret[0].([]*ifacereader.Package)
 	ret1, _ := ret[1].(error)
@@ -61,13 +61,13 @@ func (m *MockReadable) ReadPackages(_pkgDetails []*ifacereader.PackageDetails, _
 //
 //	[]*ifacereader.Package
 //	error
-func (mr *MockReadableMockRecorder) ReadPackages(_pkgDetails interface{}, _pkgNameGen interface{}) *gomock.Call {
+func (mr *MockReadableMockRecorder) ReadPackages(_pkgDetails any, _pkgNameGen any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_pkgDetails), wrapMatcher(_pkgNameGen)}
+	inputs := []any{wrapMatcher(_pkgDetails), wrapMatcher(_pkgNameGen)}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadPackages", reflect.TypeOf((*MockReadable)(nil).ReadPackages), inputs...)
 }
 
-func wrapMatcher(input interface{}) gomock.Matcher {
+func wrapMatcher(input any) gomock.Matcher {
 	if matcher, ok := input.(gomock.Matcher); ok {
 		return matcher
 	}
@@ -87,7 +87,7 @@ func wrapMatcher(input interface{}) gomock.Matcher {
 	)
 
 	return gomock.GotFormatterAdapter(
-		gomock.GotFormatterFunc(func(got interface{}) string {
+		gomock.GotFormatterFunc(func(got any) string {
 			return pretty.Sprint(got)
 		}),
 		matcher,

--- a/cmd/ensure/internal/mocks/mock_mockgen/mock_mockgen.go
+++ b/cmd/ensure/internal/mocks/mock_mockgen/mock_mockgen.go
@@ -45,7 +45,7 @@ func (m *MockGenerator) EXPECT() *MockGeneratorMockRecorder {
 // GenerateMocks mocks GenerateMocks on Generator.
 func (m *MockGenerator) GenerateMocks(_pkgs []*ifacereader.Package, _imports *uniqpkg.UniquePackagePaths, _config *ensurefile.MockConfig) ([]*mockgen.PackageMock, error) {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_pkgs, _imports, _config}
+	inputs := []any{_pkgs, _imports, _config}
 	ret := m.ctrl.Call(m, "GenerateMocks", inputs...)
 	ret0, _ := ret[0].([]*mockgen.PackageMock)
 	ret1, _ := ret[1].(error)
@@ -65,13 +65,13 @@ func (m *MockGenerator) GenerateMocks(_pkgs []*ifacereader.Package, _imports *un
 //
 //	[]*mockgen.PackageMock
 //	error
-func (mr *MockGeneratorMockRecorder) GenerateMocks(_pkgs interface{}, _imports interface{}, _config interface{}) *gomock.Call {
+func (mr *MockGeneratorMockRecorder) GenerateMocks(_pkgs any, _imports any, _config any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_pkgs), wrapMatcher(_imports), wrapMatcher(_config)}
+	inputs := []any{wrapMatcher(_pkgs), wrapMatcher(_imports), wrapMatcher(_config)}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateMocks", reflect.TypeOf((*MockGenerator)(nil).GenerateMocks), inputs...)
 }
 
-func wrapMatcher(input interface{}) gomock.Matcher {
+func wrapMatcher(input any) gomock.Matcher {
 	if matcher, ok := input.(gomock.Matcher); ok {
 		return matcher
 	}
@@ -91,7 +91,7 @@ func wrapMatcher(input interface{}) gomock.Matcher {
 	)
 
 	return gomock.GotFormatterAdapter(
-		gomock.GotFormatterFunc(func(got interface{}) string {
+		gomock.GotFormatterFunc(func(got any) string {
 			return pretty.Sprint(got)
 		}),
 		matcher,

--- a/cmd/ensure/internal/mocks/mock_mockwrite/mock_mockwrite.go
+++ b/cmd/ensure/internal/mocks/mock_mockwrite/mock_mockwrite.go
@@ -44,7 +44,7 @@ func (m *MockWritable) EXPECT() *MockWritableMockRecorder {
 // TidyMocks mocks TidyMocks on Writable.
 func (m *MockWritable) TidyMocks(_config *ensurefile.Config, _packages []*ifacereader.Package) error {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_config, _packages}
+	inputs := []any{_config, _packages}
 	ret := m.ctrl.Call(m, "TidyMocks", inputs...)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -61,16 +61,16 @@ func (m *MockWritable) TidyMocks(_config *ensurefile.Config, _packages []*ifacer
 // Outputs:
 //
 //	error
-func (mr *MockWritableMockRecorder) TidyMocks(_config interface{}, _packages interface{}) *gomock.Call {
+func (mr *MockWritableMockRecorder) TidyMocks(_config any, _packages any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_config), wrapMatcher(_packages)}
+	inputs := []any{wrapMatcher(_config), wrapMatcher(_packages)}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TidyMocks", reflect.TypeOf((*MockWritable)(nil).TidyMocks), inputs...)
 }
 
 // WriteMocks mocks WriteMocks on Writable.
 func (m *MockWritable) WriteMocks(_config *ensurefile.Config, _mocks []*mockgen.PackageMock) error {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_config, _mocks}
+	inputs := []any{_config, _mocks}
 	ret := m.ctrl.Call(m, "WriteMocks", inputs...)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -87,13 +87,13 @@ func (m *MockWritable) WriteMocks(_config *ensurefile.Config, _mocks []*mockgen.
 // Outputs:
 //
 //	error
-func (mr *MockWritableMockRecorder) WriteMocks(_config interface{}, _mocks interface{}) *gomock.Call {
+func (mr *MockWritableMockRecorder) WriteMocks(_config any, _mocks any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_config), wrapMatcher(_mocks)}
+	inputs := []any{wrapMatcher(_config), wrapMatcher(_mocks)}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteMocks", reflect.TypeOf((*MockWritable)(nil).WriteMocks), inputs...)
 }
 
-func wrapMatcher(input interface{}) gomock.Matcher {
+func wrapMatcher(input any) gomock.Matcher {
 	if matcher, ok := input.(gomock.Matcher); ok {
 		return matcher
 	}
@@ -113,7 +113,7 @@ func wrapMatcher(input interface{}) gomock.Matcher {
 	)
 
 	return gomock.GotFormatterAdapter(
-		gomock.GotFormatterFunc(func(got interface{}) string {
+		gomock.GotFormatterFunc(func(got any) string {
 			return pretty.Sprint(got)
 		}),
 		matcher,

--- a/cmd/ensure/internal/uniqpkg/uniqpkg.go
+++ b/cmd/ensure/internal/uniqpkg/uniqpkg.go
@@ -2,9 +2,10 @@
 package uniqpkg
 
 import (
+	"cmp"
 	"fmt"
 	"go/types"
-	"sort"
+	"slices"
 
 	"golang.org/x/tools/go/packages"
 )
@@ -102,8 +103,8 @@ func (pkg *Package) Imports() []*ImportDetails {
 		imports = append(imports, details)
 	}
 
-	sort.Slice(imports, func(i, j int) bool {
-		return imports[i].Path < imports[j].Path
+	slices.SortFunc(imports, func(a, b *ImportDetails) int {
+		return cmp.Compare(a.Path, b.Path)
 	})
 
 	return imports

--- a/ensuring/chain.go
+++ b/ensuring/chain.go
@@ -300,13 +300,15 @@ func formatInequalityMessage(diff []string, actual, expected any) (string, []any
 		return "\nActual %s does not equal expected %s:\n\n" + actualVsExpected, args
 	}
 
-	errors := "Actual does not equal expected:"
+	var errBuf strings.Builder
+	errBuf.WriteString("Actual does not equal expected:")
 	for _, result := range diff {
-		errors += "\n - " + result
+		errBuf.WriteString("\n - ")
+		errBuf.WriteString(result)
 	}
 
 	return "\n%s\n\n" + actualVsExpected, []any{
-		errors,
+		errBuf.String(),
 		prettyFormat(actual),
 		prettyFormat(expected),
 	}

--- a/ensuring/chain.go
+++ b/ensuring/chain.go
@@ -80,7 +80,7 @@ func (c *Chain) IsNotNil() {
 
 // Equals ensures the actual value equals the expected value.
 // Equals uses deep.Equal to print easy to read diffs.
-func (c *Chain) Equals(expected interface{}) {
+func (c *Chain) Equals(expected any) {
 	c.t.Helper()
 	c.markRun()
 
@@ -141,7 +141,7 @@ func (c *Chain) IsNotEmpty() {
 //
 //	ensure([]string{"abc", "xyz"}).Contains("xyz") // Succeeds
 //	ensure([]string{"abc", "xyz"}).Contains("y") // Fails
-func (c *Chain) Contains(expected interface{}) {
+func (c *Chain) Contains(expected any) {
 	c.t.Helper()
 	c.markRun()
 
@@ -171,7 +171,7 @@ func (c *Chain) Contains(expected interface{}) {
 //
 //	ensure([]string{"abc", "xyz"}).DoesNotContain("xyz") // Fails
 //	ensure([]string{"abc", "xyz"}).DoesNotContain("y") // Succeeds
-func (c *Chain) DoesNotContain(expected interface{}) {
+func (c *Chain) DoesNotContain(expected any) {
 	c.t.Helper()
 	c.markRun()
 
@@ -227,21 +227,21 @@ func (c *Chain) markRun() {
 	c.wasRun = true
 }
 
-func isNil(value interface{}) bool {
+func isNil(value any) bool {
 	if value == nil {
 		return true
 	}
 
 	//nolint:exhaustive // We don't want to be exhaustive here
 	switch val := reflect.ValueOf(value); val.Kind() {
-	case reflect.Ptr, reflect.Slice, reflect.Map, reflect.Func, reflect.Chan:
+	case reflect.Pointer, reflect.Slice, reflect.Map, reflect.Func, reflect.Chan:
 		return val.IsNil()
 	default:
 		return false
 	}
 }
 
-func lengthOf(value interface{}) (int, error) {
+func lengthOf(value any) (int, error) {
 	reflectValue := reflect.ValueOf(value)
 	reflectKind := reflectValue.Kind()
 	if reflectKind != reflect.Array && reflectKind != reflect.Slice && reflectKind != reflect.String && reflectKind != reflect.Map {
@@ -252,7 +252,7 @@ func lengthOf(value interface{}) (int, error) {
 	return reflectValue.Len(), nil
 }
 
-func contains(items, value interface{}) (bool, error) {
+func contains(items, value any) (bool, error) {
 	if str, strOk := items.(string); strOk {
 		substr, substrOk := value.(string)
 		if !substrOk {
@@ -280,13 +280,13 @@ func contains(items, value interface{}) (bool, error) {
 	return false, nil
 }
 
-func formatInequalityMessage(diff []string, actual, expected interface{}) (string, []interface{}) {
+func formatInequalityMessage(diff []string, actual, expected any) (string, []any) {
 	const actualVsExpected = "ACTUAL:\n%s\n\nEXPECTED:\n%s"
 
 	actualStr, actualType, actualIsStr := isStringLike(actual)
 	expectedStr, expectedType, expectedIsStr := isStringLike(expected)
 	if actualIsStr && expectedIsStr {
-		args := []interface{}{
+		args := []any{
 			actualType,
 			expectedType,
 			indent + prettyFormatString(actualStr, actualType),
@@ -305,18 +305,18 @@ func formatInequalityMessage(diff []string, actual, expected interface{}) (strin
 		errors += "\n - " + result
 	}
 
-	return "\n%s\n\n" + actualVsExpected, []interface{}{
+	return "\n%s\n\n" + actualVsExpected, []any{
 		errors,
 		prettyFormat(actual),
 		prettyFormat(expected),
 	}
 }
 
-func prettyFormat(value interface{}) string {
+func prettyFormat(value any) string {
 	return text.Indent(prettyFormatValue(value), indent)
 }
 
-func prettyFormatValue(value interface{}) string {
+func prettyFormatValue(value any) string {
 	if str, ok := value.(string); ok {
 		return prettyFormatString(str, typeString)
 	}
@@ -337,7 +337,7 @@ func prettyFormatString(str string, valType string) string {
 	return quotedString
 }
 
-func checkEquality(actual, expected interface{}) []string {
+func checkEquality(actual, expected any) []string {
 	// Since deep only supports global settings, we wrap setting them
 	// and the equality check in a mutex for concurrency safety.
 
@@ -351,7 +351,7 @@ func checkEquality(actual, expected interface{}) []string {
 	return deep.Equal(actual, expected)
 }
 
-func isStringLike(value interface{}) (string, string, bool) {
+func isStringLike(value any) (string, string, bool) {
 	if str, ok := value.(string); ok {
 		return str, typeString, true
 	}

--- a/ensuring/chain_error.go
+++ b/ensuring/chain_error.go
@@ -68,7 +68,7 @@ func (c *Chain) MatchesAllErrors(expectedErrors ...error) {
 			status = "❌"
 		}
 
-		failureDetails += fmt.Sprintf("\n\t  %s %s", status, buildExpectedErrorOutput(expected))
+		failureDetails += fmt.Sprintf("\n\t  %s %s", status, buildExpectedErrorOutput(expected)) //nolint:modernize // Clarity in test output.
 	}
 
 	if failed {

--- a/ensuring/chain_test.go
+++ b/ensuring/chain_test.go
@@ -785,7 +785,7 @@ func TestChainEquals(t *testing.T) {
 }
 
 func TestChainIsEmpty(t *testing.T) {
-	testEmptyChain(t, func(t *testing.T, valueLength int, value interface{}) {
+	testEmptyChain(t, func(t *testing.T, valueLength int, value any) {
 		mockT := setupMockTWithCleanupCheck(t)
 
 		if valueLength == 0 {
@@ -813,7 +813,7 @@ func TestChainIsEmpty(t *testing.T) {
 }
 
 func TestChainIsNotEmpty(t *testing.T) {
-	testEmptyChain(t, func(t *testing.T, valueLength int, value interface{}) {
+	testEmptyChain(t, func(t *testing.T, valueLength int, value any) {
 		mockT := setupMockTWithCleanupCheck(t)
 
 		if valueLength == 0 {
@@ -840,11 +840,11 @@ func TestChainIsNotEmpty(t *testing.T) {
 	})
 }
 
-func testEmptyChain(t *testing.T, run func(t *testing.T, valueLength int, value interface{})) {
+func testEmptyChain(t *testing.T, run func(t *testing.T, valueLength int, value any)) {
 	table := []struct {
 		Name        string
 		ValueLength int
-		Value       interface{}
+		Value       any
 	}{
 		{
 			Name:        "when empty: array",
@@ -896,7 +896,7 @@ func testEmptyChain(t *testing.T, run func(t *testing.T, valueLength int, value 
 }
 
 func TestChainContains(t *testing.T) {
-	testContainsChain(t, func(t *testing.T, doesContain bool, actual, expected interface{}, formattedActual, formattedExpected string) {
+	testContainsChain(t, func(t *testing.T, doesContain bool, actual, expected any, formattedActual, formattedExpected string) {
 		mockT := setupMockTWithCleanupCheck(t)
 
 		if doesContain {
@@ -935,7 +935,7 @@ func TestChainContains(t *testing.T) {
 }
 
 func TestChainDoesNotContain(t *testing.T) {
-	testContainsChain(t, func(t *testing.T, doesContain bool, actual, expected interface{}, formattedActual, formattedExpected string) {
+	testContainsChain(t, func(t *testing.T, doesContain bool, actual, expected any, formattedActual, formattedExpected string) {
 		mockT := setupMockTWithCleanupCheck(t)
 
 		if doesContain {
@@ -973,11 +973,11 @@ func TestChainDoesNotContain(t *testing.T) {
 	})
 }
 
-func testContainsChain(t *testing.T, run func(t *testing.T, doesContain bool, actual, expected interface{}, formattedActual, formattedExpected string)) {
+func testContainsChain(t *testing.T, run func(t *testing.T, doesContain bool, actual, expected any, formattedActual, formattedExpected string)) {
 	table := []struct {
 		Name        string
-		Actual      interface{}
-		Expected    interface{}
+		Actual      any
+		Expected    any
 		DoesContain bool
 
 		FormattedActual   string

--- a/ensuring/ensuring.go
+++ b/ensuring/ensuring.go
@@ -22,13 +22,13 @@ type T = testctx.T
 
 // E ensures the actual value is correct using [Chain].
 // E also has methods that can be called directly.
-type E func(actual interface{}) *Chain
+type E func(actual any) *Chain
 
 // Chain chains assertions to the ensure function call.
 type Chain struct {
 	t      testctx.T
 	ctx    testctx.Context
-	actual interface{}
+	actual any
 	wasRun bool
 }
 
@@ -61,7 +61,7 @@ func (e E) New(t T) E {
 
 // Failf fails the test immediately with a formatted message.
 // The formatted message follows the same format as the fmt package.
-func (e E) Failf(format string, args ...interface{}) {
+func (e E) Failf(format string, args ...any) {
 	c := e(nil)
 	c.t.Helper()
 	c.markRun()
@@ -107,7 +107,7 @@ func wrap(t T) E {
 	// Created outside the callback, so the same context is used across ensure calls
 	ctx := newTestContext(t)
 
-	return func(actual interface{}) *Chain {
+	return func(actual any) *Chain {
 		c := &Chain{
 			t:      t,
 			ctx:    ctx,
@@ -130,5 +130,5 @@ func wrap(t T) E {
 }
 
 func newTestContext(t T) testctx.Context {
-	return newTestContextFunc(t, func(t testctx.T) interface{} { return wrap(t) })
+	return newTestContextFunc(t, func(t testctx.T) any { return wrap(t) })
 }

--- a/ensuring/ensuring_test.go
+++ b/ensuring/ensuring_test.go
@@ -252,6 +252,6 @@ func setupMockTWithCleanupCheck(t *testing.T) *mock_testctx.MockT {
 	return mockT
 }
 
-func wrapEnsure(t testctx.T) interface{} {
+func wrapEnsure(t testctx.T) any {
 	return ensure.New(t)
 }

--- a/ensuring/run_table.go
+++ b/ensuring/run_table.go
@@ -38,7 +38,7 @@ import (
 //
 // Support for mocks is also included.
 // Please see the README for an example.
-func (e E) RunTableByIndex(table interface{}, fn func(ensure E, i int)) {
+func (e E) RunTableByIndex(table any, fn func(ensure E, i int)) {
 	c := e(nil)
 	c.t.Helper()
 	c.markRun()

--- a/ensuring/run_table_test.go
+++ b/ensuring/run_table_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestERunTableByIndex(t *testing.T) {
 	runTableConfig{
-		prepare: func(ensure ensuring.E) func(table interface{}, fn func(ensure ensuring.E, i int)) {
+		prepare: func(ensure ensuring.E) func(table any, fn func(ensure ensuring.E, i int)) {
 			return ensure.RunTableByIndex
 		},
 	}.test(t)
@@ -29,13 +29,13 @@ type runTableTestEntry struct {
 	ExpectedNames        []string
 	ExpectedTableSize    int // Defaults to the length of ExpectedNames
 	FatalMessagesContain []string
-	Table                interface{}
-	CheckEntry           func(t *testing.T, rawEntry interface{})
+	Table                any
+	CheckEntry           func(t *testing.T, rawEntry any)
 }
 
 type runTableConfig struct {
 	isSync  bool
-	prepare func(ensure ensuring.E) func(table interface{}, fn func(ensure ensuring.E, i int))
+	prepare func(ensure ensuring.E) func(table any, fn func(ensure ensuring.E, i int))
 }
 
 func (cfg runTableConfig) test(t *testing.T) {
@@ -70,7 +70,7 @@ func (cfg runTableConfig) test(t *testing.T) {
 			innerMockTs := []*mock_testctx.MockT{} //lint:ignore ST1003 mockTs not mockTS
 
 			actualFatalMessages := []string{}
-			fatalMessagesRecorder := func(msg string, args ...interface{}) {
+			fatalMessagesRecorder := func(msg string, args ...any) {
 				actualFatalMessages = append(actualFatalMessages, msg)
 			}
 
@@ -123,7 +123,7 @@ func (cfg runTableConfig) test(t *testing.T) {
 			// Run calls should be in order
 			gomock.InOrder(expectedRunCalls...)
 
-			outerMockT.EXPECT().Fatalf(gomock.Any()).Do(func(msg string, args ...interface{}) {
+			outerMockT.EXPECT().Fatalf(gomock.Any()).Do(func(msg string, args ...any) {
 				actualFatalMessages = append(actualFatalMessages, msg)
 			}).AnyTimes()
 
@@ -498,7 +498,7 @@ func (runTableTests) mocksField() runTableTestEntryGroup {
 					},
 				},
 
-				CheckEntry: func(t *testing.T, rawTable interface{}) {
+				CheckEntry: func(t *testing.T, rawTable any) {
 					table := rawTable.([]struct {
 						Name  string
 						Mocks *TwoValidMocks
@@ -525,7 +525,7 @@ func (runTableTests) mocksField() runTableTestEntryGroup {
 					},
 				},
 
-				CheckEntry: func(t *testing.T, rawTable interface{}) {
+				CheckEntry: func(t *testing.T, rawTable any) {
 					table := rawTable.([]struct {
 						Name  string
 						Mocks *TwoValidMocksWithUnexported
@@ -552,7 +552,7 @@ func (runTableTests) mocksField() runTableTestEntryGroup {
 					},
 				},
 
-				CheckEntry: func(t *testing.T, rawTable interface{}) {
+				CheckEntry: func(t *testing.T, rawTable any) {
 					table := rawTable.([]struct {
 						Name  string
 						Mocks *TwoValidMocksWithEmbedded
@@ -579,7 +579,7 @@ func (runTableTests) mocksField() runTableTestEntryGroup {
 					},
 				},
 
-				CheckEntry: func(t *testing.T, rawTable interface{}) {
+				CheckEntry: func(t *testing.T, rawTable any) {
 					table := rawTable.([]struct {
 						Name  string
 						Mocks *OneMockNEWMethodZeroParams
@@ -607,7 +607,7 @@ func (runTableTests) mocksField() runTableTestEntryGroup {
 					},
 				},
 
-				CheckEntry: func(t *testing.T, rawTable interface{}) {
+				CheckEntry: func(t *testing.T, rawTable any) {
 					table := rawTable.([]struct {
 						Name  string
 						Mocks *TwoValidMocksWithEmbeddedPtr
@@ -778,7 +778,7 @@ func (runTableTests) mocksField() runTableTestEntryGroup {
 					},
 				},
 
-				CheckEntry: func(t *testing.T, rawTable interface{}) {
+				CheckEntry: func(t *testing.T, rawTable any) {
 					table := rawTable.([]struct {
 						Name  string
 						Mocks *DuplicateMocks
@@ -820,7 +820,7 @@ func (runTableTests) setupMocksField() runTableTestEntryGroup {
 					},
 				},
 
-				CheckEntry: func(t *testing.T, rawTable interface{}) {
+				CheckEntry: func(t *testing.T, rawTable any) {
 					table := rawTable.([]struct {
 						Name       string
 						Mocks      *TwoValidMocks
@@ -858,7 +858,7 @@ func (runTableTests) setupMocksField() runTableTestEntryGroup {
 					},
 				},
 
-				CheckEntry: func(t *testing.T, rawTable interface{}) {
+				CheckEntry: func(t *testing.T, rawTable any) {
 					table := rawTable.([]struct {
 						Name       string
 						Mocks      *TwoValidMocks
@@ -891,7 +891,7 @@ func (runTableTests) setupMocksField() runTableTestEntryGroup {
 					},
 				},
 
-				CheckEntry: func(t *testing.T, rawTable interface{}) {
+				CheckEntry: func(t *testing.T, rawTable any) {
 					table := rawTable.([]struct {
 						Name       string
 						Mocks      *TwoValidMocks
@@ -1048,7 +1048,7 @@ func (runTableTests) subjectField() runTableTestEntryGroup {
 					},
 				},
 
-				CheckEntry: func(t *testing.T, rawTable interface{}) {
+				CheckEntry: func(t *testing.T, rawTable any) {
 					table := rawTable.([]struct {
 						Name    string
 						Mocks   *OneValidMock
@@ -1077,7 +1077,7 @@ func (runTableTests) subjectField() runTableTestEntryGroup {
 					},
 				},
 
-				CheckEntry: func(t *testing.T, rawTable interface{}) {
+				CheckEntry: func(t *testing.T, rawTable any) {
 					table := rawTable.([]struct {
 						Name    string
 						Subject *MultiInterfaceSubject
@@ -1105,7 +1105,7 @@ func (runTableTests) subjectField() runTableTestEntryGroup {
 					},
 				},
 
-				CheckEntry: func(t *testing.T, rawTable interface{}) {
+				CheckEntry: func(t *testing.T, rawTable any) {
 					table := rawTable.([]struct {
 						Name    string
 						Mocks   *OneValidMock
@@ -1172,7 +1172,7 @@ func (runTableTests) subjectField() runTableTestEntryGroup {
 					},
 				},
 
-				CheckEntry: func(t *testing.T, rawTable interface{}) {
+				CheckEntry: func(t *testing.T, rawTable any) {
 					table := rawTable.([]struct {
 						Name    string
 						Mocks   *OneValidMock
@@ -1204,7 +1204,7 @@ func (runTableTests) subjectField() runTableTestEntryGroup {
 					},
 				},
 
-				CheckEntry: func(t *testing.T, rawTable interface{}) {
+				CheckEntry: func(t *testing.T, rawTable any) {
 					table := rawTable.([]struct {
 						Name    string
 						Mocks   *OneValidMock
@@ -1270,7 +1270,7 @@ func (runTableTests) subjectField() runTableTestEntryGroup {
 					},
 				},
 
-				CheckEntry: func(t *testing.T, rawTable interface{}) {
+				CheckEntry: func(t *testing.T, rawTable any) {
 					table := rawTable.([]struct {
 						Name    string
 						Mocks   *TwoValidMocksWithIgnoreUnusedTag

--- a/ensuring/synctest.go
+++ b/ensuring/synctest.go
@@ -37,7 +37,7 @@ func (e E) RunSync(name string, fn func(ensure E)) {
 // code that uses [time.Sleep]. See the [synctest] docs for more info.
 //
 // See [E.RunTableByIndex] for more info on table driven testing.
-func (e E) RunTableByIndexSync(table interface{}, fn func(ensure E, i int)) {
+func (e E) RunTableByIndexSync(table any, fn func(ensure E, i int)) {
 	c := e(nil)
 	c.t.Helper()
 	c.markRun()

--- a/ensuring/synctest_test.go
+++ b/ensuring/synctest_test.go
@@ -20,7 +20,7 @@ func TestERunSync(t *testing.T) {
 func TestERunTableByIndexSync(t *testing.T) {
 	runTableConfig{
 		isSync: true,
-		prepare: func(ensure ensuring.E) func(table interface{}, fn func(ensure ensuring.E, i int)) {
+		prepare: func(ensure ensuring.E) func(table any, fn func(ensure ensuring.E, i int)) {
 			return ensure.RunTableByIndexSync
 		},
 	}.test(t)

--- a/exp/entable/internal/mocks/github.com/JosiahWitt/ensure/mock_ensuring/mock_ensuring.go
+++ b/exp/entable/internal/mocks/github.com/JosiahWitt/ensure/mock_ensuring/mock_ensuring.go
@@ -42,7 +42,7 @@ func (m *MockT) EXPECT() *MockTMockRecorder {
 // Cleanup mocks Cleanup on T.
 func (m *MockT) Cleanup(_f func()) {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_f}
+	inputs := []any{_f}
 	ret := m.ctrl.Call(m, "Cleanup", inputs...)
 	var _ = ret // Unused, since there are no returns
 	return
@@ -58,16 +58,16 @@ func (m *MockT) Cleanup(_f func()) {
 // Outputs:
 //
 //	none
-func (mr *MockTMockRecorder) Cleanup(_f interface{}) *gomock.Call {
+func (mr *MockTMockRecorder) Cleanup(_f any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_f)}
+	inputs := []any{wrapMatcher(_f)}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cleanup", reflect.TypeOf((*MockT)(nil).Cleanup), inputs...)
 }
 
 // Errorf mocks Errorf on T.
 func (m *MockT) Errorf(_format string, _args ...interface{}) {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_format}
+	inputs := []any{_format}
 	for _, variadicInput := range _args {
 		inputs = append(inputs, variadicInput)
 	}
@@ -87,9 +87,9 @@ func (m *MockT) Errorf(_format string, _args ...interface{}) {
 // Outputs:
 //
 //	none
-func (mr *MockTMockRecorder) Errorf(_format interface{}, _args ...interface{}) *gomock.Call {
+func (mr *MockTMockRecorder) Errorf(_format any, _args ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_format)}
+	inputs := []any{wrapMatcher(_format)}
 	for _, variadicInput := range _args {
 		inputs = append(inputs, wrapMatcher(variadicInput))
 	}
@@ -99,7 +99,7 @@ func (mr *MockTMockRecorder) Errorf(_format interface{}, _args ...interface{}) *
 // Fatalf mocks Fatalf on T.
 func (m *MockT) Fatalf(_format string, _args ...interface{}) {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_format}
+	inputs := []any{_format}
 	for _, variadicInput := range _args {
 		inputs = append(inputs, variadicInput)
 	}
@@ -119,9 +119,9 @@ func (m *MockT) Fatalf(_format string, _args ...interface{}) {
 // Outputs:
 //
 //	none
-func (mr *MockTMockRecorder) Fatalf(_format interface{}, _args ...interface{}) *gomock.Call {
+func (mr *MockTMockRecorder) Fatalf(_format any, _args ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_format)}
+	inputs := []any{wrapMatcher(_format)}
 	for _, variadicInput := range _args {
 		inputs = append(inputs, wrapMatcher(variadicInput))
 	}
@@ -131,7 +131,7 @@ func (mr *MockTMockRecorder) Fatalf(_format interface{}, _args ...interface{}) *
 // Helper mocks Helper on T.
 func (m *MockT) Helper() {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{}
+	inputs := []any{}
 	ret := m.ctrl.Call(m, "Helper", inputs...)
 	var _ = ret // Unused, since there are no returns
 	return
@@ -149,14 +149,14 @@ func (m *MockT) Helper() {
 //	none
 func (mr *MockTMockRecorder) Helper() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{}
+	inputs := []any{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Helper", reflect.TypeOf((*MockT)(nil).Helper), inputs...)
 }
 
 // Logf mocks Logf on T.
 func (m *MockT) Logf(_format string, _args ...interface{}) {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_format}
+	inputs := []any{_format}
 	for _, variadicInput := range _args {
 		inputs = append(inputs, variadicInput)
 	}
@@ -176,9 +176,9 @@ func (m *MockT) Logf(_format string, _args ...interface{}) {
 // Outputs:
 //
 //	none
-func (mr *MockTMockRecorder) Logf(_format interface{}, _args ...interface{}) *gomock.Call {
+func (mr *MockTMockRecorder) Logf(_format any, _args ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_format)}
+	inputs := []any{wrapMatcher(_format)}
 	for _, variadicInput := range _args {
 		inputs = append(inputs, wrapMatcher(variadicInput))
 	}
@@ -188,7 +188,7 @@ func (mr *MockTMockRecorder) Logf(_format interface{}, _args ...interface{}) *go
 // Parallel mocks Parallel on T.
 func (m *MockT) Parallel() {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{}
+	inputs := []any{}
 	ret := m.ctrl.Call(m, "Parallel", inputs...)
 	var _ = ret // Unused, since there are no returns
 	return
@@ -206,14 +206,14 @@ func (m *MockT) Parallel() {
 //	none
 func (mr *MockTMockRecorder) Parallel() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{}
+	inputs := []any{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Parallel", reflect.TypeOf((*MockT)(nil).Parallel), inputs...)
 }
 
 // Run mocks Run on T.
 func (m *MockT) Run(_name string, _f func(t *testing.T)) bool {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_name, _f}
+	inputs := []any{_name, _f}
 	ret := m.ctrl.Call(m, "Run", inputs...)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -230,13 +230,13 @@ func (m *MockT) Run(_name string, _f func(t *testing.T)) bool {
 // Outputs:
 //
 //	bool
-func (mr *MockTMockRecorder) Run(_name interface{}, _f interface{}) *gomock.Call {
+func (mr *MockTMockRecorder) Run(_name any, _f any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_name), wrapMatcher(_f)}
+	inputs := []any{wrapMatcher(_name), wrapMatcher(_f)}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockT)(nil).Run), inputs...)
 }
 
-func wrapMatcher(input interface{}) gomock.Matcher {
+func wrapMatcher(input any) gomock.Matcher {
 	if matcher, ok := input.(gomock.Matcher); ok {
 		return matcher
 	}
@@ -256,7 +256,7 @@ func wrapMatcher(input interface{}) gomock.Matcher {
 	)
 
 	return gomock.GotFormatterAdapter(
-		gomock.GotFormatterFunc(func(got interface{}) string {
+		gomock.GotFormatterFunc(func(got any) string {
 			return pretty.Sprint(got)
 		}),
 		matcher,

--- a/internal/integration_test_suite/go125_test.go
+++ b/internal/integration_test_suite/go125_test.go
@@ -56,7 +56,7 @@ func TestRunTableByIndexSync(t *testing.T) {
 		assertShorterThan(t, time.Since(start), 10*time.Second)
 	})
 
-	sharedEnsureRunTableByIndexTests(t, func(ensure ensuring.E) func(table interface{}, fn func(ensure ensuring.E, i int)) {
+	sharedEnsureRunTableByIndexTests(t, func(ensure ensuring.E) func(table any, fn func(ensure ensuring.E, i int)) {
 		return ensure.RunTableByIndexSync
 	})
 }

--- a/internal/integration_test_suite/methods_test.go
+++ b/internal/integration_test_suite/methods_test.go
@@ -69,12 +69,12 @@ func TestRunParallel(t *testing.T) {
 }
 
 func TestRunTableByIndex(t *testing.T) {
-	sharedEnsureRunTableByIndexTests(t, func(ensure ensuring.E) func(table interface{}, fn func(ensure ensuring.E, i int)) {
+	sharedEnsureRunTableByIndexTests(t, func(ensure ensuring.E) func(table any, fn func(ensure ensuring.E, i int)) {
 		return ensure.RunTableByIndex
 	})
 }
 
-func sharedEnsureRunTableByIndexTests(t *testing.T, prepare func(ensure ensuring.E) func(table interface{}, fn func(ensure ensuring.E, i int))) {
+func sharedEnsureRunTableByIndexTests(t *testing.T, prepare func(ensure ensuring.E) func(table any, fn func(ensure ensuring.E, i int))) {
 	t.Run("entries are executed in nested scope when entries are not pointers", func(t *testing.T) {
 		namePrefix := t.Name()
 		ensure := ensure.New(t)
@@ -164,7 +164,7 @@ func sharedEnsureRunTableByIndexTests(t *testing.T, prepare func(ensure ensuring
 				Location: "world",
 
 				SetupMocks: func(m *Mocks) {
-					m.T.EXPECT().Logf("hello world").Do(func(format string, args ...interface{}) {
+					m.T.EXPECT().Logf("hello world").Do(func(format string, args ...any) {
 						loggedMessages = append(loggedMessages, format)
 					})
 				},
@@ -175,7 +175,7 @@ func sharedEnsureRunTableByIndexTests(t *testing.T, prepare func(ensure ensuring
 				Location: "universe",
 
 				SetupMocks: func(m *Mocks) {
-					m.T.EXPECT().Logf("hello universe").Do(func(format string, args ...interface{}) {
+					m.T.EXPECT().Logf("hello universe").Do(func(format string, args ...any) {
 						loggedMessages = append(loggedMessages, format)
 					})
 				},
@@ -198,7 +198,7 @@ func TestT(t *testing.T) {
 	assertEq(t, ensure.T(), t)
 }
 
-func assertEq(t *testing.T, actual, expected interface{}) {
+func assertEq(t *testing.T, actual, expected any) {
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("%+v != %+v", actual, expected)
 	}

--- a/internal/mocks/mock_testctx/mock_testctx.go
+++ b/internal/mocks/mock_testctx/mock_testctx.go
@@ -43,7 +43,7 @@ func (m *MockT) EXPECT() *MockTMockRecorder {
 // Cleanup mocks Cleanup on T.
 func (m *MockT) Cleanup(_f func()) {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_f}
+	inputs := []any{_f}
 	ret := m.ctrl.Call(m, "Cleanup", inputs...)
 	var _ = ret // Unused, since there are no returns
 	return
@@ -59,16 +59,16 @@ func (m *MockT) Cleanup(_f func()) {
 // Outputs:
 //
 //	none
-func (mr *MockTMockRecorder) Cleanup(_f interface{}) *gomock.Call {
+func (mr *MockTMockRecorder) Cleanup(_f any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_f)}
+	inputs := []any{wrapMatcher(_f)}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cleanup", reflect.TypeOf((*MockT)(nil).Cleanup), inputs...)
 }
 
 // Errorf mocks Errorf on T.
-func (m *MockT) Errorf(_format string, _args ...interface{}) {
+func (m *MockT) Errorf(_format string, _args ...any) {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_format}
+	inputs := []any{_format}
 	for _, variadicInput := range _args {
 		inputs = append(inputs, variadicInput)
 	}
@@ -83,14 +83,14 @@ func (m *MockT) Errorf(_format string, _args ...interface{}) {
 // Inputs:
 //
 //	format string
-//	args ...interface{}
+//	args ...any
 //
 // Outputs:
 //
 //	none
-func (mr *MockTMockRecorder) Errorf(_format interface{}, _args ...interface{}) *gomock.Call {
+func (mr *MockTMockRecorder) Errorf(_format any, _args ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_format)}
+	inputs := []any{wrapMatcher(_format)}
 	for _, variadicInput := range _args {
 		inputs = append(inputs, wrapMatcher(variadicInput))
 	}
@@ -98,9 +98,9 @@ func (mr *MockTMockRecorder) Errorf(_format interface{}, _args ...interface{}) *
 }
 
 // Fatalf mocks Fatalf on T.
-func (m *MockT) Fatalf(_format string, _args ...interface{}) {
+func (m *MockT) Fatalf(_format string, _args ...any) {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_format}
+	inputs := []any{_format}
 	for _, variadicInput := range _args {
 		inputs = append(inputs, variadicInput)
 	}
@@ -115,14 +115,14 @@ func (m *MockT) Fatalf(_format string, _args ...interface{}) {
 // Inputs:
 //
 //	format string
-//	args ...interface{}
+//	args ...any
 //
 // Outputs:
 //
 //	none
-func (mr *MockTMockRecorder) Fatalf(_format interface{}, _args ...interface{}) *gomock.Call {
+func (mr *MockTMockRecorder) Fatalf(_format any, _args ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_format)}
+	inputs := []any{wrapMatcher(_format)}
 	for _, variadicInput := range _args {
 		inputs = append(inputs, wrapMatcher(variadicInput))
 	}
@@ -132,7 +132,7 @@ func (mr *MockTMockRecorder) Fatalf(_format interface{}, _args ...interface{}) *
 // Helper mocks Helper on T.
 func (m *MockT) Helper() {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{}
+	inputs := []any{}
 	ret := m.ctrl.Call(m, "Helper", inputs...)
 	var _ = ret // Unused, since there are no returns
 	return
@@ -150,14 +150,14 @@ func (m *MockT) Helper() {
 //	none
 func (mr *MockTMockRecorder) Helper() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{}
+	inputs := []any{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Helper", reflect.TypeOf((*MockT)(nil).Helper), inputs...)
 }
 
 // Logf mocks Logf on T.
-func (m *MockT) Logf(_format string, _args ...interface{}) {
+func (m *MockT) Logf(_format string, _args ...any) {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_format}
+	inputs := []any{_format}
 	for _, variadicInput := range _args {
 		inputs = append(inputs, variadicInput)
 	}
@@ -172,14 +172,14 @@ func (m *MockT) Logf(_format string, _args ...interface{}) {
 // Inputs:
 //
 //	format string
-//	args ...interface{}
+//	args ...any
 //
 // Outputs:
 //
 //	none
-func (mr *MockTMockRecorder) Logf(_format interface{}, _args ...interface{}) *gomock.Call {
+func (mr *MockTMockRecorder) Logf(_format any, _args ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_format)}
+	inputs := []any{wrapMatcher(_format)}
 	for _, variadicInput := range _args {
 		inputs = append(inputs, wrapMatcher(variadicInput))
 	}
@@ -189,7 +189,7 @@ func (mr *MockTMockRecorder) Logf(_format interface{}, _args ...interface{}) *go
 // Parallel mocks Parallel on T.
 func (m *MockT) Parallel() {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{}
+	inputs := []any{}
 	ret := m.ctrl.Call(m, "Parallel", inputs...)
 	var _ = ret // Unused, since there are no returns
 	return
@@ -207,14 +207,14 @@ func (m *MockT) Parallel() {
 //	none
 func (mr *MockTMockRecorder) Parallel() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{}
+	inputs := []any{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Parallel", reflect.TypeOf((*MockT)(nil).Parallel), inputs...)
 }
 
 // Run mocks Run on T.
 func (m *MockT) Run(_name string, _f func(t *testing.T)) bool {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_name, _f}
+	inputs := []any{_name, _f}
 	ret := m.ctrl.Call(m, "Run", inputs...)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -231,9 +231,9 @@ func (m *MockT) Run(_name string, _f func(t *testing.T)) bool {
 // Outputs:
 //
 //	bool
-func (mr *MockTMockRecorder) Run(_name interface{}, _f interface{}) *gomock.Call {
+func (mr *MockTMockRecorder) Run(_name any, _f any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_name), wrapMatcher(_f)}
+	inputs := []any{wrapMatcher(_name), wrapMatcher(_f)}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockT)(nil).Run), inputs...)
 }
 
@@ -266,11 +266,11 @@ func (m *MockContext) EXPECT() *MockContextMockRecorder {
 }
 
 // Ensure mocks Ensure on Context.
-func (m *MockContext) Ensure() interface{} {
+func (m *MockContext) Ensure() any {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{}
+	inputs := []any{}
 	ret := m.ctrl.Call(m, "Ensure", inputs...)
-	ret0, _ := ret[0].(interface{})
+	ret0, _ := ret[0].(any)
 	return ret0
 }
 
@@ -283,17 +283,17 @@ func (m *MockContext) Ensure() interface{} {
 //
 // Outputs:
 //
-//	interface{}
+//	any
 func (mr *MockContextMockRecorder) Ensure() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{}
+	inputs := []any{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ensure", reflect.TypeOf((*MockContext)(nil).Ensure), inputs...)
 }
 
 // GoMockController mocks GoMockController on Context.
 func (m *MockContext) GoMockController() *gomock.Controller {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{}
+	inputs := []any{}
 	ret := m.ctrl.Call(m, "GoMockController", inputs...)
 	ret0, _ := ret[0].(*gomock.Controller)
 	return ret0
@@ -311,14 +311,14 @@ func (m *MockContext) GoMockController() *gomock.Controller {
 //	*gomock.Controller
 func (mr *MockContextMockRecorder) GoMockController() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{}
+	inputs := []any{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GoMockController", reflect.TypeOf((*MockContext)(nil).GoMockController), inputs...)
 }
 
 // Run mocks Run on Context.
 func (m *MockContext) Run(_name string, _fn func(testctx.Context)) {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_name, _fn}
+	inputs := []any{_name, _fn}
 	ret := m.ctrl.Call(m, "Run", inputs...)
 	var _ = ret // Unused, since there are no returns
 	return
@@ -335,16 +335,16 @@ func (m *MockContext) Run(_name string, _fn func(testctx.Context)) {
 // Outputs:
 //
 //	none
-func (mr *MockContextMockRecorder) Run(_name interface{}, _fn interface{}) *gomock.Call {
+func (mr *MockContextMockRecorder) Run(_name any, _fn any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_name), wrapMatcher(_fn)}
+	inputs := []any{wrapMatcher(_name), wrapMatcher(_fn)}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockContext)(nil).Run), inputs...)
 }
 
 // T mocks T on Context.
 func (m *MockContext) T() testctx.T {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{}
+	inputs := []any{}
 	ret := m.ctrl.Call(m, "T", inputs...)
 	ret0, _ := ret[0].(testctx.T)
 	return ret0
@@ -362,7 +362,7 @@ func (m *MockContext) T() testctx.T {
 //	testctx.T
 func (mr *MockContextMockRecorder) T() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{}
+	inputs := []any{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "T", reflect.TypeOf((*MockContext)(nil).T), inputs...)
 }
 
@@ -395,11 +395,11 @@ func (m *MockSyncableContext) EXPECT() *MockSyncableContextMockRecorder {
 }
 
 // Ensure mocks Ensure on SyncableContext.
-func (m *MockSyncableContext) Ensure() interface{} {
+func (m *MockSyncableContext) Ensure() any {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{}
+	inputs := []any{}
 	ret := m.ctrl.Call(m, "Ensure", inputs...)
-	ret0, _ := ret[0].(interface{})
+	ret0, _ := ret[0].(any)
 	return ret0
 }
 
@@ -412,17 +412,17 @@ func (m *MockSyncableContext) Ensure() interface{} {
 //
 // Outputs:
 //
-//	interface{}
+//	any
 func (mr *MockSyncableContextMockRecorder) Ensure() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{}
+	inputs := []any{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ensure", reflect.TypeOf((*MockSyncableContext)(nil).Ensure), inputs...)
 }
 
 // GoMockController mocks GoMockController on SyncableContext.
 func (m *MockSyncableContext) GoMockController() *gomock.Controller {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{}
+	inputs := []any{}
 	ret := m.ctrl.Call(m, "GoMockController", inputs...)
 	ret0, _ := ret[0].(*gomock.Controller)
 	return ret0
@@ -440,14 +440,14 @@ func (m *MockSyncableContext) GoMockController() *gomock.Controller {
 //	*gomock.Controller
 func (mr *MockSyncableContextMockRecorder) GoMockController() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{}
+	inputs := []any{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GoMockController", reflect.TypeOf((*MockSyncableContext)(nil).GoMockController), inputs...)
 }
 
 // Run mocks Run on SyncableContext.
 func (m *MockSyncableContext) Run(_name string, _fn func(testctx.Context)) {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_name, _fn}
+	inputs := []any{_name, _fn}
 	ret := m.ctrl.Call(m, "Run", inputs...)
 	var _ = ret // Unused, since there are no returns
 	return
@@ -464,16 +464,16 @@ func (m *MockSyncableContext) Run(_name string, _fn func(testctx.Context)) {
 // Outputs:
 //
 //	none
-func (mr *MockSyncableContextMockRecorder) Run(_name interface{}, _fn interface{}) *gomock.Call {
+func (mr *MockSyncableContextMockRecorder) Run(_name any, _fn any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_name), wrapMatcher(_fn)}
+	inputs := []any{wrapMatcher(_name), wrapMatcher(_fn)}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockSyncableContext)(nil).Run), inputs...)
 }
 
 // Sync mocks Sync on SyncableContext.
 func (m *MockSyncableContext) Sync(_fn func(testctx.Context)) {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{_fn}
+	inputs := []any{_fn}
 	ret := m.ctrl.Call(m, "Sync", inputs...)
 	var _ = ret // Unused, since there are no returns
 	return
@@ -489,16 +489,16 @@ func (m *MockSyncableContext) Sync(_fn func(testctx.Context)) {
 // Outputs:
 //
 //	none
-func (mr *MockSyncableContextMockRecorder) Sync(_fn interface{}) *gomock.Call {
+func (mr *MockSyncableContextMockRecorder) Sync(_fn any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{wrapMatcher(_fn)}
+	inputs := []any{wrapMatcher(_fn)}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockSyncableContext)(nil).Sync), inputs...)
 }
 
 // T mocks T on SyncableContext.
 func (m *MockSyncableContext) T() testctx.T {
 	m.ctrl.T.Helper()
-	inputs := []interface{}{}
+	inputs := []any{}
 	ret := m.ctrl.Call(m, "T", inputs...)
 	ret0, _ := ret[0].(testctx.T)
 	return ret0
@@ -516,11 +516,11 @@ func (m *MockSyncableContext) T() testctx.T {
 //	testctx.T
 func (mr *MockSyncableContextMockRecorder) T() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	inputs := []interface{}{}
+	inputs := []any{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "T", reflect.TypeOf((*MockSyncableContext)(nil).T), inputs...)
 }
 
-func wrapMatcher(input interface{}) gomock.Matcher {
+func wrapMatcher(input any) gomock.Matcher {
 	if matcher, ok := input.(gomock.Matcher); ok {
 		return matcher
 	}
@@ -540,7 +540,7 @@ func wrapMatcher(input interface{}) gomock.Matcher {
 	)
 
 	return gomock.GotFormatterAdapter(
-		gomock.GotFormatterFunc(func(got interface{}) string {
+		gomock.GotFormatterFunc(func(got any) string {
 			return pretty.Sprint(got)
 		}),
 		matcher,

--- a/internal/plugins/internal/iterate/struct_fields.go
+++ b/internal/plugins/internal/iterate/struct_fields.go
@@ -55,14 +55,13 @@ func (si *structIterator) process(prefix string, t reflect.Type) (*StructFieldsR
 		fieldPath := prefix + "." + fieldName
 
 		// Skip unexported fields
-		// TODO: Swap to use the IsExported method once Go 1.17 is the minimum supported version
-		if field.PkgPath != "" {
+		if !field.IsExported() {
 			continue
 		}
 
 		// Support embedded types (anonymous fields)
 		if field.Anonymous {
-			isPointer := fieldKind == reflect.Ptr
+			isPointer := fieldKind == reflect.Pointer
 			isPointerToStruct := isPointer && fieldType.Elem().Kind() == reflect.Struct
 
 			// Embedded structs and pointers to structs are recursed into for their promoted fields
@@ -140,7 +139,7 @@ func (r *StructFieldsResult) InitializeStruct(v reflect.Value, iterator Initiali
 func (r *StructFieldsResult) initialize(v reflect.Value) {
 	t := v.Type()
 
-	if t.Kind() != reflect.Ptr || t.Elem().Kind() != reflect.Struct {
+	if t.Kind() != reflect.Pointer || t.Elem().Kind() != reflect.Struct {
 		panicf("InitializeStruct must be provided a pointer to a struct, got: %v", t)
 	}
 
@@ -184,13 +183,13 @@ func (r *StructFieldsResult) iterate(v reflect.Value, iterator func(fieldPath st
 }
 
 func indirectType(t reflect.Type) reflect.Type {
-	if t.Kind() != reflect.Ptr {
+	if t.Kind() != reflect.Pointer {
 		return t
 	}
 
 	return indirectType(t.Elem())
 }
 
-func panicf(format string, a ...interface{}) {
+func panicf(format string, a ...any) {
 	panic(fmt.Sprintf(format, a...))
 }

--- a/internal/plugins/internal/iterate/struct_fields_test.go
+++ b/internal/plugins/internal/iterate/struct_fields_test.go
@@ -26,7 +26,7 @@ func TestStructFields(t *testing.T) {
 	table := []struct {
 		Name string
 
-		Struct   interface{}
+		Struct   any
 		Iterator func(fieldPath string, field *reflect.StructField) []error
 
 		ExpectedFields []*Field
@@ -63,15 +63,15 @@ func TestStructFields(t *testing.T) {
 			ExpectedFields: []*Field{
 				{
 					FieldPath: prefix + ".AStruct",
-					Type:      reflect.TypeOf(&struct{}{}),
+					Type:      reflect.TypeFor[*struct{}](),
 				},
 				{
 					FieldPath: prefix + ".AString",
-					Type:      reflect.TypeOf(""),
+					Type:      reflect.TypeFor[string](),
 				},
 				{
 					FieldPath: prefix + ".AnInterface",
-					Type:      reflect.TypeOf((*interface{ B() int })(nil)).Elem(),
+					Type:      reflect.TypeFor[interface{ B() int }](),
 				},
 			},
 		},
@@ -93,15 +93,15 @@ func TestStructFields(t *testing.T) {
 			ExpectedFields: []*Field{
 				{
 					FieldPath: prefix + ".AStruct",
-					Type:      reflect.TypeOf(&struct{}{}),
+					Type:      reflect.TypeFor[*struct{}](),
 				},
 				{
 					FieldPath: prefix + ".AString",
-					Type:      reflect.TypeOf(""),
+					Type:      reflect.TypeFor[string](),
 				},
 				{
 					FieldPath: prefix + ".AnInterface",
-					Type:      reflect.TypeOf((*interface{ B() int })(nil)).Elem(),
+					Type:      reflect.TypeFor[interface{ B() int }](),
 				},
 			},
 		},
@@ -127,15 +127,15 @@ func TestStructFields(t *testing.T) {
 			ExpectedFields: []*Field{
 				{
 					FieldPath: prefix + ".AStruct",
-					Type:      reflect.TypeOf(&struct{}{}),
+					Type:      reflect.TypeFor[*struct{}](),
 				},
 				{
 					FieldPath: prefix + ".AString",
-					Type:      reflect.TypeOf(""),
+					Type:      reflect.TypeFor[string](),
 				},
 				{
 					FieldPath: prefix + ".AnInterface",
-					Type:      reflect.TypeOf((*interface{ B() int })(nil)).Elem(),
+					Type:      reflect.TypeFor[interface{ B() int }](),
 				},
 			},
 
@@ -164,31 +164,31 @@ func TestStructFields(t *testing.T) {
 			ExpectedFields: []*Field{
 				{
 					FieldPath: prefix + ".Anonymous1.AStruct",
-					Type:      reflect.TypeOf(&struct{}{}),
+					Type:      reflect.TypeFor[*struct{}](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous1.AString",
-					Type:      reflect.TypeOf(""),
+					Type:      reflect.TypeFor[string](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous1.AnInterface",
-					Type:      reflect.TypeOf((*interface{ B() int })(nil)).Elem(),
+					Type:      reflect.TypeFor[interface{ B() int }](),
 				},
 				{
 					FieldPath: prefix + ".AStruct",
-					Type:      reflect.TypeOf(&struct{}{}),
+					Type:      reflect.TypeFor[*struct{}](),
 				},
 				{
 					FieldPath: prefix + ".AString",
-					Type:      reflect.TypeOf(""),
+					Type:      reflect.TypeFor[string](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous2.AnInt",
-					Type:      reflect.TypeOf(0),
+					Type:      reflect.TypeFor[int](),
 				},
 				{
 					FieldPath: prefix + ".AnInterface",
-					Type:      reflect.TypeOf((*interface{ B() int })(nil)).Elem(),
+					Type:      reflect.TypeFor[interface{ B() int }](),
 				},
 			},
 		},
@@ -212,31 +212,31 @@ func TestStructFields(t *testing.T) {
 			ExpectedFields: []*Field{
 				{
 					FieldPath: prefix + ".Anonymous1.AStruct",
-					Type:      reflect.TypeOf(&struct{}{}),
+					Type:      reflect.TypeFor[*struct{}](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous1.AString",
-					Type:      reflect.TypeOf(""),
+					Type:      reflect.TypeFor[string](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous1.AnInterface",
-					Type:      reflect.TypeOf((*interface{ B() int })(nil)).Elem(),
+					Type:      reflect.TypeFor[interface{ B() int }](),
 				},
 				{
 					FieldPath: prefix + ".AStruct",
-					Type:      reflect.TypeOf(&struct{}{}),
+					Type:      reflect.TypeFor[*struct{}](),
 				},
 				{
 					FieldPath: prefix + ".AString",
-					Type:      reflect.TypeOf(""),
+					Type:      reflect.TypeFor[string](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous2.AnInt",
-					Type:      reflect.TypeOf(0),
+					Type:      reflect.TypeFor[int](),
 				},
 				{
 					FieldPath: prefix + ".AnInterface",
-					Type:      reflect.TypeOf((*interface{ B() int })(nil)).Elem(),
+					Type:      reflect.TypeFor[interface{ B() int }](),
 				},
 			},
 		},
@@ -260,39 +260,39 @@ func TestStructFields(t *testing.T) {
 			ExpectedFields: []*Field{
 				{
 					FieldPath: prefix + ".Anonymous1Nested.AFloat",
-					Type:      reflect.TypeOf(0.0),
+					Type:      reflect.TypeFor[float64](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous1Nested.Anonymous1.AStruct",
-					Type:      reflect.TypeOf(&struct{}{}),
+					Type:      reflect.TypeFor[*struct{}](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous1Nested.Anonymous1.AString",
-					Type:      reflect.TypeOf(""),
+					Type:      reflect.TypeFor[string](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous1Nested.Anonymous1.AnInterface",
-					Type:      reflect.TypeOf((*interface{ B() int })(nil)).Elem(),
+					Type:      reflect.TypeFor[interface{ B() int }](),
 				},
 				{
 					FieldPath: prefix + ".AStruct",
-					Type:      reflect.TypeOf(&struct{}{}),
+					Type:      reflect.TypeFor[*struct{}](),
 				},
 				{
 					FieldPath: prefix + ".AString",
-					Type:      reflect.TypeOf(""),
+					Type:      reflect.TypeFor[string](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous2Nested.ABool",
-					Type:      reflect.TypeOf(false),
+					Type:      reflect.TypeFor[bool](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous2Nested.Anonymous2.AnInt",
-					Type:      reflect.TypeOf(0),
+					Type:      reflect.TypeFor[int](),
 				},
 				{
 					FieldPath: prefix + ".AnInterface",
-					Type:      reflect.TypeOf((*interface{ B() int })(nil)).Elem(),
+					Type:      reflect.TypeFor[interface{ B() int }](),
 				},
 			},
 		},
@@ -317,35 +317,35 @@ func TestStructFields(t *testing.T) {
 			ExpectedFields: []*Field{
 				{
 					FieldPath: prefix + ".AString",
-					Type:      reflect.TypeOf(""),
+					Type:      reflect.TypeFor[string](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous1.AStruct",
-					Type:      reflect.TypeOf(&struct{}{}),
+					Type:      reflect.TypeFor[*struct{}](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous1.AString",
-					Type:      reflect.TypeOf(""),
+					Type:      reflect.TypeFor[string](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous1.AnInterface",
-					Type:      reflect.TypeOf((*interface{ B() int })(nil)).Elem(),
+					Type:      reflect.TypeFor[interface{ B() int }](),
 				},
 				{
 					FieldPath: prefix + ".AStruct",
-					Type:      reflect.TypeOf(&struct{ Different bool }{}),
+					Type:      reflect.TypeFor[*struct{ Different bool }](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous2.AnInt",
-					Type:      reflect.TypeOf(0),
+					Type:      reflect.TypeFor[int](),
 				},
 				{
 					FieldPath: prefix + ".AnInt",
-					Type:      reflect.TypeOf(0),
+					Type:      reflect.TypeFor[int](),
 				},
 				{
 					FieldPath: prefix + ".AnInterface",
-					Type:      reflect.TypeOf((*interface{ B() int })(nil)).Elem(),
+					Type:      reflect.TypeFor[interface{ B() int }](),
 				},
 			},
 		},
@@ -369,35 +369,35 @@ func TestStructFields(t *testing.T) {
 			ExpectedFields: []*Field{
 				{
 					FieldPath: prefix + ".AnonymousRecursiveNested.ABool",
-					Type:      reflect.TypeOf(false),
+					Type:      reflect.TypeFor[bool](),
 				},
 				{
 					FieldPath: prefix + ".AnonymousRecursiveNested.ASlice",
-					Type:      reflect.TypeOf([]string{}),
+					Type:      reflect.TypeFor[[]string](),
 				},
 				{
 					FieldPath: prefix + ".AStruct",
-					Type:      reflect.TypeOf(&struct{}{}),
+					Type:      reflect.TypeFor[*struct{}](),
 				},
 				{
 					FieldPath: prefix + ".AString",
-					Type:      reflect.TypeOf(""),
+					Type:      reflect.TypeFor[string](),
 				},
 				{
 					FieldPath: prefix + ".AnonymousDoubleRecursiveNested.AnInt",
-					Type:      reflect.TypeOf(0),
+					Type:      reflect.TypeFor[int](),
 				},
 				{
 					FieldPath: prefix + ".AnonymousDoubleRecursiveNested.AnonymousRecursiveNested.ABool",
-					Type:      reflect.TypeOf(false),
+					Type:      reflect.TypeFor[bool](),
 				},
 				{
 					FieldPath: prefix + ".AnonymousDoubleRecursiveNested.AnonymousRecursiveNested.ASlice",
-					Type:      reflect.TypeOf([]string{}),
+					Type:      reflect.TypeFor[[]string](),
 				},
 				{
 					FieldPath: prefix + ".AnInterface",
-					Type:      reflect.TypeOf((*interface{ B() int })(nil)).Elem(),
+					Type:      reflect.TypeFor[interface{ B() int }](),
 				},
 			},
 		},
@@ -422,35 +422,35 @@ func TestStructFields(t *testing.T) {
 			ExpectedFields: []*Field{
 				{
 					FieldPath: prefix + ".AnonymousInterface",
-					Type:      reflect.TypeOf((*AnonymousInterface)(nil)).Elem(),
+					Type:      reflect.TypeFor[AnonymousInterface](),
 				},
 				{
 					FieldPath: prefix + ".AnonymousSlice",
-					Type:      reflect.TypeOf(AnonymousSlice{}),
+					Type:      reflect.TypeFor[AnonymousSlice](),
 				},
 				{
 					FieldPath: prefix + ".AnonymousMap",
-					Type:      reflect.TypeOf(AnonymousMap{}),
+					Type:      reflect.TypeFor[AnonymousMap](),
 				},
 				{
 					FieldPath: prefix + ".AnonymousChan",
-					Type:      reflect.TypeOf(AnonymousChan(nil)),
+					Type:      reflect.TypeFor[AnonymousChan](),
 				},
 				{
 					FieldPath: prefix + ".AnonymousInt",
-					Type:      reflect.TypeOf(AnonymousInt(0)),
+					Type:      reflect.TypeFor[AnonymousInt](),
 				},
 				{
 					FieldPath: prefix + ".AnonymousFunc",
-					Type:      reflect.TypeOf(AnonymousFunc(nil)),
+					Type:      reflect.TypeFor[AnonymousFunc](),
 				},
 				{
 					FieldPath: prefix + ".AnonymousString",
-					Type:      reflect.TypeOf((*AnonymousString)(nil)),
+					Type:      reflect.TypeFor[*AnonymousString](),
 				},
 				{
 					FieldPath: prefix + ".AString",
-					Type:      reflect.TypeOf(""),
+					Type:      reflect.TypeFor[string](),
 				},
 			},
 		},
@@ -471,27 +471,27 @@ func TestStructFields(t *testing.T) {
 			ExpectedFields: []*Field{
 				{
 					FieldPath: prefix + ".Anonymous1.AStruct",
-					Type:      reflect.TypeOf(&struct{}{}),
+					Type:      reflect.TypeFor[*struct{}](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous1.AString",
-					Type:      reflect.TypeOf(""),
+					Type:      reflect.TypeFor[string](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous1.AnInterface",
-					Type:      reflect.TypeOf((*interface{ B() int })(nil)).Elem(),
+					Type:      reflect.TypeFor[interface{ B() int }](),
 				},
 				{
 					FieldPath: prefix + ".AnonymousInterface",
-					Type:      reflect.TypeOf((*AnonymousInterface)(nil)).Elem(),
+					Type:      reflect.TypeFor[AnonymousInterface](),
 				},
 				{
 					FieldPath: prefix + ".AnonymousSlice",
-					Type:      reflect.TypeOf(AnonymousSlice{}),
+					Type:      reflect.TypeFor[AnonymousSlice](),
 				},
 				{
 					FieldPath: prefix + ".AString",
-					Type:      reflect.TypeOf(""),
+					Type:      reflect.TypeFor[string](),
 				},
 			},
 		},
@@ -513,11 +513,11 @@ func TestStructFields(t *testing.T) {
 			ExpectedFields: []*Field{
 				{
 					FieldPath: prefix + ".AnonymousInterface",
-					Type:      reflect.TypeOf((*AnonymousInterface)(nil)).Elem(),
+					Type:      reflect.TypeFor[AnonymousInterface](),
 				},
 				{
 					FieldPath: prefix + ".AString",
-					Type:      reflect.TypeOf(""),
+					Type:      reflect.TypeFor[string](),
 				},
 			},
 
@@ -549,39 +549,39 @@ func TestStructFields(t *testing.T) {
 			ExpectedFields: []*Field{
 				{
 					FieldPath: prefix + ".Anonymous1Nested.AFloat",
-					Type:      reflect.TypeOf(0.0),
+					Type:      reflect.TypeFor[float64](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous1Nested.Anonymous1.AStruct",
-					Type:      reflect.TypeOf(&struct{}{}),
+					Type:      reflect.TypeFor[*struct{}](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous1Nested.Anonymous1.AString",
-					Type:      reflect.TypeOf(""),
+					Type:      reflect.TypeFor[string](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous1Nested.Anonymous1.AnInterface",
-					Type:      reflect.TypeOf((*interface{ B() int })(nil)).Elem(),
+					Type:      reflect.TypeFor[interface{ B() int }](),
 				},
 				{
 					FieldPath: prefix + ".AStruct",
-					Type:      reflect.TypeOf(&struct{}{}),
+					Type:      reflect.TypeFor[*struct{}](),
 				},
 				{
 					FieldPath: prefix + ".AString",
-					Type:      reflect.TypeOf(""),
+					Type:      reflect.TypeFor[string](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous2Nested.ABool",
-					Type:      reflect.TypeOf(false),
+					Type:      reflect.TypeFor[bool](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous2Nested.Anonymous2.AnInt",
-					Type:      reflect.TypeOf(0),
+					Type:      reflect.TypeFor[int](),
 				},
 				{
 					FieldPath: prefix + ".AnInterface",
-					Type:      reflect.TypeOf((*interface{ B() int })(nil)).Elem(),
+					Type:      reflect.TypeFor[interface{ B() int }](),
 				},
 			},
 
@@ -611,7 +611,7 @@ func TestStructFields(t *testing.T) {
 			ensure(recover()).Equals("StructFields must be provided a struct, got: string")
 		}()
 
-		iterate.StructFields("", reflect.TypeOf("not a struct"), nil)
+		iterate.StructFields("", reflect.TypeFor[string](), nil)
 	})
 }
 
@@ -630,10 +630,10 @@ func TestInitializeStruct(t *testing.T) {
 	table := []struct {
 		Name string
 
-		NestedStruct interface{}
+		NestedStruct any
 		Iterator     iterate.InitializeStructIterator
 
-		ExpectedInitializedStruct interface{}
+		ExpectedInitializedStruct any
 		ExpectedFields            []*Field
 	}{
 		{
@@ -685,15 +685,15 @@ func TestInitializeStruct(t *testing.T) {
 			ExpectedFields: []*Field{
 				{
 					FieldPath: prefix + ".AStruct",
-					Type:      reflect.TypeOf(&struct{}{}),
+					Type:      reflect.TypeFor[*struct{}](),
 				},
 				{
 					FieldPath: prefix + ".AString",
-					Type:      reflect.TypeOf(""),
+					Type:      reflect.TypeFor[string](),
 				},
 				{
 					FieldPath: prefix + ".AnInterface",
-					Type:      reflect.TypeOf((*interface{ B() int })(nil)).Elem(),
+					Type:      reflect.TypeFor[interface{ B() int }](),
 				},
 			},
 		},
@@ -729,31 +729,31 @@ func TestInitializeStruct(t *testing.T) {
 			ExpectedFields: []*Field{
 				{
 					FieldPath: prefix + ".AStruct",
-					Type:      reflect.TypeOf(&struct{}{}),
+					Type:      reflect.TypeFor[*struct{}](),
 				},
 				{
 					FieldPath: prefix + ".AString",
-					Type:      reflect.TypeOf(""),
+					Type:      reflect.TypeFor[string](),
 				},
 				{
 					FieldPath: prefix + ".AnInterface",
-					Type:      reflect.TypeOf((*interface{ B() int })(nil)).Elem(),
+					Type:      reflect.TypeFor[interface{ B() int }](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous1.AStruct",
-					Type:      reflect.TypeOf(&struct{}{}),
+					Type:      reflect.TypeFor[*struct{}](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous1.AString",
-					Type:      reflect.TypeOf(""),
+					Type:      reflect.TypeFor[string](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous1.AnInterface",
-					Type:      reflect.TypeOf((*interface{ B() int })(nil)).Elem(),
+					Type:      reflect.TypeFor[interface{ B() int }](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous2.AnInt",
-					Type:      reflect.TypeOf(1),
+					Type:      reflect.TypeFor[int](),
 				},
 			},
 		},
@@ -789,31 +789,31 @@ func TestInitializeStruct(t *testing.T) {
 			ExpectedFields: []*Field{
 				{
 					FieldPath: prefix + ".AStruct",
-					Type:      reflect.TypeOf(&struct{}{}),
+					Type:      reflect.TypeFor[*struct{}](),
 				},
 				{
 					FieldPath: prefix + ".AString",
-					Type:      reflect.TypeOf(""),
+					Type:      reflect.TypeFor[string](),
 				},
 				{
 					FieldPath: prefix + ".AnInterface",
-					Type:      reflect.TypeOf((*interface{ B() int })(nil)).Elem(),
+					Type:      reflect.TypeFor[interface{ B() int }](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous1.AStruct",
-					Type:      reflect.TypeOf(&struct{}{}),
+					Type:      reflect.TypeFor[*struct{}](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous1.AString",
-					Type:      reflect.TypeOf(""),
+					Type:      reflect.TypeFor[string](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous1.AnInterface",
-					Type:      reflect.TypeOf((*interface{ B() int })(nil)).Elem(),
+					Type:      reflect.TypeFor[interface{ B() int }](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous2.AnInt",
-					Type:      reflect.TypeOf(1),
+					Type:      reflect.TypeFor[int](),
 				},
 			},
 		},
@@ -853,39 +853,39 @@ func TestInitializeStruct(t *testing.T) {
 			ExpectedFields: []*Field{
 				{
 					FieldPath: prefix + ".AStruct",
-					Type:      reflect.TypeOf(&struct{ Name string }{}),
+					Type:      reflect.TypeFor[*struct{ Name string }](),
 				},
 				{
 					FieldPath: prefix + ".AString",
-					Type:      reflect.TypeOf(""),
+					Type:      reflect.TypeFor[string](),
 				},
 				{
 					FieldPath: prefix + ".AnInterface",
-					Type:      reflect.TypeOf((*interface{ B() int })(nil)).Elem(),
+					Type:      reflect.TypeFor[interface{ B() int }](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous1Nested.AFloat",
-					Type:      reflect.TypeOf(1.0),
+					Type:      reflect.TypeFor[float64](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous1Nested.Anonymous1.AStruct",
-					Type:      reflect.TypeOf(&struct{}{}),
+					Type:      reflect.TypeFor[*struct{}](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous1Nested.Anonymous1.AString",
-					Type:      reflect.TypeOf(""),
+					Type:      reflect.TypeFor[string](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous1Nested.Anonymous1.AnInterface",
-					Type:      reflect.TypeOf((*interface{ B() int })(nil)).Elem(),
+					Type:      reflect.TypeFor[interface{ B() int }](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous2Nested.ABool",
-					Type:      reflect.TypeOf(false),
+					Type:      reflect.TypeFor[bool](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous2Nested.Anonymous2.AnInt",
-					Type:      reflect.TypeOf(1),
+					Type:      reflect.TypeFor[int](),
 				},
 			},
 		},
@@ -924,35 +924,35 @@ func TestInitializeStruct(t *testing.T) {
 			ExpectedFields: []*Field{
 				{
 					FieldPath: prefix + ".AStruct",
-					Type:      reflect.TypeOf(&struct{}{}),
+					Type:      reflect.TypeFor[*struct{}](),
 				},
 				{
 					FieldPath: prefix + ".AString",
-					Type:      reflect.TypeOf(""),
+					Type:      reflect.TypeFor[string](),
 				},
 				{
 					FieldPath: prefix + ".AnInterface",
-					Type:      reflect.TypeOf((*interface{ B() int })(nil)).Elem(),
+					Type:      reflect.TypeFor[interface{ B() int }](),
 				},
 				{
 					FieldPath: prefix + ".AnonymousRecursiveNested.ABool",
-					Type:      reflect.TypeOf(false),
+					Type:      reflect.TypeFor[bool](),
 				},
 				{
 					FieldPath: prefix + ".AnonymousRecursiveNested.ASlice",
-					Type:      reflect.TypeOf([]string{}),
+					Type:      reflect.TypeFor[[]string](),
 				},
 				{
 					FieldPath: prefix + ".AnonymousDoubleRecursiveNested.AnInt",
-					Type:      reflect.TypeOf(0),
+					Type:      reflect.TypeFor[int](),
 				},
 				{
 					FieldPath: prefix + ".AnonymousDoubleRecursiveNested.AnonymousRecursiveNested.ABool",
-					Type:      reflect.TypeOf(false),
+					Type:      reflect.TypeFor[bool](),
 				},
 				{
 					FieldPath: prefix + ".AnonymousDoubleRecursiveNested.AnonymousRecursiveNested.ASlice",
-					Type:      reflect.TypeOf([]string{}),
+					Type:      reflect.TypeFor[[]string](),
 				},
 			},
 		},
@@ -1027,63 +1027,63 @@ func TestInitializeStruct(t *testing.T) {
 			ExpectedFields: []*Field{
 				{
 					FieldPath: prefix + ".AStruct",
-					Type:      reflect.TypeOf(&struct{ Name string }{}),
+					Type:      reflect.TypeFor[*struct{ Name string }](),
 				},
 				{
 					FieldPath: prefix + ".AString",
-					Type:      reflect.TypeOf(""),
+					Type:      reflect.TypeFor[string](),
 				},
 				{
 					FieldPath: prefix + ".AnInterface",
-					Type:      reflect.TypeOf((*interface{ B() int })(nil)).Elem(),
+					Type:      reflect.TypeFor[interface{ B() int }](),
 				},
 				{
 					FieldPath: prefix + ".ASlice",
-					Type:      reflect.TypeOf([]string{}),
+					Type:      reflect.TypeFor[[]string](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous1Nested.AFloat",
-					Type:      reflect.TypeOf(1.0),
+					Type:      reflect.TypeFor[float64](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous1Nested.Anonymous1.AStruct",
-					Type:      reflect.TypeOf(&struct{}{}),
+					Type:      reflect.TypeFor[*struct{}](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous1Nested.Anonymous1.AString",
-					Type:      reflect.TypeOf(""),
+					Type:      reflect.TypeFor[string](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous1Nested.Anonymous1.AnInterface",
-					Type:      reflect.TypeOf((*interface{ B() int })(nil)).Elem(),
+					Type:      reflect.TypeFor[interface{ B() int }](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous2Nested.ABool",
-					Type:      reflect.TypeOf(false),
+					Type:      reflect.TypeFor[bool](),
 				},
 				{
 					FieldPath: prefix + ".Anonymous2Nested.Anonymous2.AnInt",
-					Type:      reflect.TypeOf(1),
+					Type:      reflect.TypeFor[int](),
 				},
 				{
 					FieldPath: prefix + ".AnonymousRecursiveNested.ABool",
-					Type:      reflect.TypeOf(false),
+					Type:      reflect.TypeFor[bool](),
 				},
 				{
 					FieldPath: prefix + ".AnonymousRecursiveNested.ASlice",
-					Type:      reflect.TypeOf([]string{}),
+					Type:      reflect.TypeFor[[]string](),
 				},
 				{
 					FieldPath: prefix + ".AnonymousDoubleRecursiveNested.AnInt",
-					Type:      reflect.TypeOf(0),
+					Type:      reflect.TypeFor[int](),
 				},
 				{
 					FieldPath: prefix + ".AnonymousDoubleRecursiveNested.AnonymousRecursiveNested.ABool",
-					Type:      reflect.TypeOf(false),
+					Type:      reflect.TypeFor[bool](),
 				},
 				{
 					FieldPath: prefix + ".AnonymousDoubleRecursiveNested.AnonymousRecursiveNested.ASlice",
-					Type:      reflect.TypeOf([]string{}),
+					Type:      reflect.TypeFor[[]string](),
 				},
 			},
 		},
@@ -1113,7 +1113,7 @@ func TestInitializeStruct(t *testing.T) {
 			ensure(recover()).Equals("InitializeStruct must be provided a pointer to a struct, got: struct {}")
 		}()
 
-		res, errs := iterate.StructFields(prefix, reflect.TypeOf(struct{}{}), noopStructFieldsIterator)
+		res, errs := iterate.StructFields(prefix, reflect.TypeFor[struct{}](), noopStructFieldsIterator)
 		ensure(errs).IsNotError()
 
 		res.InitializeStruct(reflect.ValueOf(struct{}{}), nil)
@@ -1124,7 +1124,7 @@ func TestInitializeStruct(t *testing.T) {
 			ensure(recover()).Equals("InitializeStruct must be provided a pointer to a struct, got: *string")
 		}()
 
-		res, errs := iterate.StructFields(prefix, reflect.TypeOf(struct{}{}), noopStructFieldsIterator)
+		res, errs := iterate.StructFields(prefix, reflect.TypeFor[struct{}](), noopStructFieldsIterator)
 		ensure(errs).IsNotError()
 
 		str := "not a struct"
@@ -1140,7 +1140,7 @@ func TestInitializeStruct(t *testing.T) {
 		type s1 struct{}
 		type s2 struct{}
 
-		res, errs := iterate.StructFields(prefix, reflect.TypeOf(s1{}), noopStructFieldsIterator)
+		res, errs := iterate.StructFields(prefix, reflect.TypeFor[s1](), noopStructFieldsIterator)
 		ensure(errs).IsNotError()
 
 		res.InitializeStruct(reflect.ValueOf(&s2{}), nil)
@@ -1153,7 +1153,7 @@ func TestInitializeStruct(t *testing.T) {
 
 		type s struct{}
 
-		res, errs := iterate.StructFields(prefix, reflect.TypeOf(s{}), noopStructFieldsIterator)
+		res, errs := iterate.StructFields(prefix, reflect.TypeFor[s](), noopStructFieldsIterator)
 		ensure(errs).IsNotError()
 
 		res.InitializeStruct(reflect.ValueOf(&s{}), nil)

--- a/internal/plugins/internal/mocks/mocks_test.go
+++ b/internal/plugins/internal/mocks/mocks_test.go
@@ -15,8 +15,8 @@ func TestAllAddMock(t *testing.T) {
 
 	ensure.Run("adds mock", func(ensure ensuring.E) {
 		m := mocks.All{}
-		m1 := m.AddMock("a", true, reflect.TypeOf(&ExampleGreeterMock{}))
-		m2 := m.AddMock("b", false, reflect.TypeOf(&ExampleOtherMock{}))
+		m1 := m.AddMock("a", true, reflect.TypeFor[*ExampleGreeterMock]())
+		m2 := m.AddMock("b", false, reflect.TypeFor[*ExampleOtherMock]())
 
 		ensure(m1.Path).Equals("a")
 		ensure(m1.Optional).Equals(true)
@@ -37,9 +37,9 @@ func TestAllAddMock(t *testing.T) {
 		}()
 
 		m := mocks.All{}
-		m.AddMock("a", true, reflect.TypeOf(""))
-		m.AddMock("b", true, reflect.TypeOf(1))
-		m.AddMock("a", true, reflect.TypeOf(false))
+		m.AddMock("a", true, reflect.TypeFor[string]())
+		m.AddMock("b", true, reflect.TypeFor[int]())
+		m.AddMock("a", true, reflect.TypeFor[bool]())
 	})
 }
 
@@ -53,8 +53,8 @@ func TestAllSlice(t *testing.T) {
 
 	ensure.Run("when many items", func(ensure ensuring.E) {
 		m := mocks.All{}
-		m.AddMock("a", true, reflect.TypeOf(&ExampleGreeterMock{}))
-		m.AddMock("b", false, reflect.TypeOf(&ExampleOtherMock{}))
+		m.AddMock("a", true, reflect.TypeFor[*ExampleGreeterMock]())
+		m.AddMock("b", false, reflect.TypeFor[*ExampleOtherMock]())
 
 		ensure(m.Slice()[0].Path).Equals("a")
 		ensure(m.Slice()[0].Optional).IsTrue()
@@ -76,8 +76,8 @@ func TestAllPathSet(t *testing.T) {
 
 	ensure.Run("when many items", func(ensure ensuring.E) {
 		m := mocks.All{}
-		m.AddMock("a", true, reflect.TypeOf(&ExampleGreeterMock{}))
-		m.AddMock("b", false, reflect.TypeOf(&ExampleOtherMock{}))
+		m.AddMock("a", true, reflect.TypeFor[*ExampleGreeterMock]())
+		m.AddMock("b", false, reflect.TypeFor[*ExampleOtherMock]())
 
 		ensure(m.PathSet()).Equals(mocks.PathSet{"a": struct{}{}, "b": struct{}{}})
 	})
@@ -88,14 +88,14 @@ func TestMockImplements(t *testing.T) {
 
 	ensure.Run("when interface is provided", func(ensure ensuring.E) {
 		m := mocks.All{}
-		m.AddMock("a", true, reflect.TypeOf(&ExampleGreeterMock{}))
-		m.AddMock("b", false, reflect.TypeOf(&ExampleOtherMock{}))
+		m.AddMock("a", true, reflect.TypeFor[*ExampleGreeterMock]())
+		m.AddMock("b", false, reflect.TypeFor[*ExampleOtherMock]())
 
 		type Greeter interface{ Hello(string) string }
 		type Bingo interface{ Bingo(string) bool }
 
-		greeter := reflect.TypeOf((*Greeter)(nil)).Elem()
-		bingo := reflect.TypeOf((*Bingo)(nil)).Elem()
+		greeter := reflect.TypeFor[Greeter]()
+		bingo := reflect.TypeFor[Bingo]()
 
 		ensure(m.Slice()[0].Implements(greeter)).IsTrue()
 		ensure(m.Slice()[0].Implements(bingo)).IsFalse()
@@ -109,8 +109,8 @@ func TestMockImplements(t *testing.T) {
 		}()
 
 		m := mocks.All{}
-		m.AddMock("a", true, reflect.TypeOf(&ExampleGreeterMock{}))
-		m.Slice()[0].Implements(reflect.TypeOf("not interface"))
+		m.AddMock("a", true, reflect.TypeFor[*ExampleGreeterMock]())
+		m.Slice()[0].Implements(reflect.TypeFor[string]())
 	})
 }
 
@@ -119,8 +119,8 @@ func TestMockSetValueByEntryIndex(t *testing.T) {
 
 	ensure.Run("sets values correctly", func(ensure ensuring.E) {
 		m := mocks.All{}
-		m.AddMock("a", true, reflect.TypeOf(&ExampleGreeterMock{}))
-		m.AddMock("b", false, reflect.TypeOf(&ExampleOtherMock{}))
+		m.AddMock("a", true, reflect.TypeFor[*ExampleGreeterMock]())
+		m.AddMock("b", false, reflect.TypeFor[*ExampleOtherMock]())
 
 		m.Slice()[0].SetValueByEntryIndex(5, reflect.ValueOf(&ExampleGreeterMock{"hey"}))
 		m.Slice()[1].SetValueByEntryIndex(1, reflect.ValueOf(&ExampleOtherMock{"over"}))
@@ -136,8 +136,8 @@ func TestMockSetValueByEntryIndex(t *testing.T) {
 		}()
 
 		m := mocks.All{}
-		m.AddMock("a", true, reflect.TypeOf(&ExampleGreeterMock{}))
-		m.AddMock("b", false, reflect.TypeOf(&ExampleOtherMock{}))
+		m.AddMock("a", true, reflect.TypeFor[*ExampleGreeterMock]())
+		m.AddMock("b", false, reflect.TypeFor[*ExampleOtherMock]())
 
 		m.Slice()[0].SetValueByEntryIndex(5, reflect.ValueOf("hey"))
 	})
@@ -148,8 +148,8 @@ func TestMockSetValueByEntryIndex(t *testing.T) {
 		}()
 
 		m := mocks.All{}
-		m.AddMock("a", true, reflect.TypeOf(&ExampleGreeterMock{}))
-		m.AddMock("b", false, reflect.TypeOf(&ExampleOtherMock{}))
+		m.AddMock("a", true, reflect.TypeFor[*ExampleGreeterMock]())
+		m.AddMock("b", false, reflect.TypeFor[*ExampleOtherMock]())
 
 		m.Slice()[0].SetValueByEntryIndex(5, reflect.ValueOf(&ExampleGreeterMock{"hey"}))
 		m.Slice()[0].SetValueByEntryIndex(5, reflect.ValueOf(&ExampleGreeterMock{"there"}))
@@ -161,8 +161,8 @@ func TestMockValueByEntryIndex(t *testing.T) {
 
 	ensure.Run("gets values correctly", func(ensure ensuring.E) {
 		m := mocks.All{}
-		m.AddMock("a", true, reflect.TypeOf(&ExampleGreeterMock{}))
-		m.AddMock("b", false, reflect.TypeOf(&ExampleOtherMock{}))
+		m.AddMock("a", true, reflect.TypeFor[*ExampleGreeterMock]())
+		m.AddMock("b", false, reflect.TypeFor[*ExampleOtherMock]())
 
 		m.Slice()[0].SetValueByEntryIndex(5, reflect.ValueOf(&ExampleGreeterMock{"hey"}))
 		m.Slice()[1].SetValueByEntryIndex(1, reflect.ValueOf(&ExampleOtherMock{"over"}))
@@ -178,8 +178,8 @@ func TestMockValueByEntryIndex(t *testing.T) {
 		}()
 
 		m := mocks.All{}
-		m.AddMock("a", true, reflect.TypeOf(&ExampleGreeterMock{}))
-		m.AddMock("b", false, reflect.TypeOf(&ExampleOtherMock{}))
+		m.AddMock("a", true, reflect.TypeFor[*ExampleGreeterMock]())
+		m.AddMock("b", false, reflect.TypeFor[*ExampleOtherMock]())
 
 		ensure(m.Slice()[0].ValueByEntryIndex(5).Interface()).Equals(&ExampleGreeterMock{"there"})
 	})

--- a/internal/plugins/internal/testhelper/testhelper.go
+++ b/internal/plugins/internal/testhelper/testhelper.go
@@ -12,8 +12,8 @@ type MockData struct {
 	Path     string
 	Optional bool
 
-	Mock   interface{}
-	Values []interface{}
+	Mock   any
+	Values []any
 }
 
 // BuildMocks builds all the provided mocks into [mocks.All].

--- a/internal/plugins/mocks/mocks.go
+++ b/internal/plugins/mocks/mocks.go
@@ -15,7 +15,7 @@ import (
 )
 
 //nolint:gochecknoglobals // This is only used internally for comparison.
-var goMockControllerType = reflect.TypeOf(&gomock.Controller{})
+var goMockControllerType = reflect.TypeFor[*gomock.Controller]()
 
 // New uses the collection of mocks, initializing and populating it for each test entry.
 func New(m *mocks.All) *TablePlugin {
@@ -57,7 +57,7 @@ func (t *TablePlugin) ParseEntryType(entryType reflect.Type) (plugins.TableEntry
 func validateMocksFieldType(mocksStruct *reflect.StructField) error {
 	t := mocksStruct.Type
 
-	if t.Kind() != reflect.Ptr || t.Elem().Kind() != reflect.Struct {
+	if t.Kind() != reflect.Pointer || t.Elem().Kind() != reflect.Struct {
 		return stringerr.Newf("expected %s field to be a pointer to a struct, got %s", id.Mocks, t)
 	}
 
@@ -78,7 +78,7 @@ func (t *TablePlugin) parseMocks(mocksStruct *reflect.StructField) (map[string]*
 			return nil
 		}
 
-		if mocksField.Type.Kind() != reflect.Ptr || mocksField.Type.Elem().Kind() != reflect.Struct {
+		if mocksField.Type.Kind() != reflect.Pointer || mocksField.Type.Elem().Kind() != reflect.Struct {
 			return []error{stringerr.Newf(
 				"%s is expected to be a pointer to a struct, got: %v. To ignore %[1]s, add the %[4]s tag.",
 				mocksFieldPath,

--- a/internal/plugins/mocks/mocks_test.go
+++ b/internal/plugins/mocks/mocks_test.go
@@ -21,7 +21,7 @@ func TestParseEntryType(t *testing.T) {
 		Name string
 
 		MocksInput *mocks.All
-		Entry      interface{}
+		Entry      any
 
 		ExpectedMocks *mocks.All
 		ExpectedError error
@@ -531,9 +531,9 @@ func TestParseEntryValue(t *testing.T) {
 		Name string
 
 		MocksInput *mocks.All
-		Table      interface{}
+		Table      any
 
-		ExpectedTable interface{}
+		ExpectedTable any
 		ExpectedMocks *mocks.All
 	}{
 		{
@@ -638,7 +638,7 @@ func TestParseEntryValue(t *testing.T) {
 				{
 					Path: "Mocks.M1",
 					Mock: &MockNoInsNEW{},
-					Values: []interface{}{
+					Values: []any{
 						expectedMockNoInsNEW(),
 						expectedMockNoInsNEW(),
 					},
@@ -646,7 +646,7 @@ func TestParseEntryValue(t *testing.T) {
 				{
 					Path: "Mocks.M2",
 					Mock: &MockGoMocksNEW{},
-					Values: []interface{}{
+					Values: []any{
 						expectedMockGoMocksNEW(0),
 						expectedMockGoMocksNEW(1),
 					},
@@ -699,7 +699,7 @@ func TestParseEntryValue(t *testing.T) {
 				{
 					Path: "Mocks.AllMocks.M1",
 					Mock: &MockNoInsNEW{},
-					Values: []interface{}{
+					Values: []any{
 						expectedMockNoInsNEW(),
 						expectedMockNoInsNEW(),
 					},
@@ -707,7 +707,7 @@ func TestParseEntryValue(t *testing.T) {
 				{
 					Path: "Mocks.AllMocks.M2",
 					Mock: &MockGoMocksNEW{},
-					Values: []interface{}{
+					Values: []any{
 						expectedMockGoMocksNEW(0),
 						expectedMockGoMocksNEW(1),
 					},
@@ -715,7 +715,7 @@ func TestParseEntryValue(t *testing.T) {
 				{
 					Path: "Mocks.M1",
 					Mock: &MockNoInsNEW{},
-					Values: []interface{}{
+					Values: []any{
 						expectedMockNoInsNEW(),
 						expectedMockNoInsNEW(),
 					},
@@ -723,7 +723,7 @@ func TestParseEntryValue(t *testing.T) {
 				{
 					Path: "Mocks.M2",
 					Mock: &MockGoMocksNEW{},
-					Values: []interface{}{
+					Values: []any{
 						expectedMockGoMocksNEW(0),
 						expectedMockGoMocksNEW(1),
 					},
@@ -768,7 +768,7 @@ func TestParseEntryValue(t *testing.T) {
 				{
 					Path: "Mocks.M1",
 					Mock: &MockNoInsNEW{},
-					Values: []interface{}{
+					Values: []any{
 						expectedMockNoInsNEW(),
 						expectedMockNoInsNEW(),
 					},
@@ -777,7 +777,7 @@ func TestParseEntryValue(t *testing.T) {
 					Path:     "Mocks.M2",
 					Mock:     &MockGoMocksNEW{},
 					Optional: true,
-					Values: []interface{}{
+					Values: []any{
 						expectedMockGoMocksNEW(0),
 						expectedMockGoMocksNEW(1),
 					},
@@ -785,7 +785,7 @@ func TestParseEntryValue(t *testing.T) {
 				{
 					Path: "Mocks.M3",
 					Mock: &MockNoInsNEW{},
-					Values: []interface{}{
+					Values: []any{
 						expectedMockNoInsNEW(),
 						expectedMockNoInsNEW(),
 					},
@@ -828,7 +828,7 @@ func TestParseEntryValue(t *testing.T) {
 				{
 					Path: "Mocks.M1",
 					Mock: &MockNoInsNEW{},
-					Values: []interface{}{
+					Values: []any{
 						expectedMockNoInsNEW(),
 						expectedMockNoInsNEW(),
 					},
@@ -836,7 +836,7 @@ func TestParseEntryValue(t *testing.T) {
 				{
 					Path: "Mocks.M3",
 					Mock: &MockGoMocksNEW{},
-					Values: []interface{}{
+					Values: []any{
 						expectedMockGoMocksNEW(0),
 						expectedMockGoMocksNEW(1),
 					},

--- a/internal/plugins/setupmocks/setupmocks_test.go
+++ b/internal/plugins/setupmocks/setupmocks_test.go
@@ -18,7 +18,7 @@ func TestParseEntryType(t *testing.T) {
 	table := []struct {
 		Name string
 
-		Entry interface{}
+		Entry any
 
 		ExpectedError error
 	}{
@@ -209,10 +209,10 @@ func TestParseEntryValue(t *testing.T) {
 	table := []struct {
 		Name string
 
-		Table      interface{}
+		Table      any
 		SetupMockT func(m *mock_testctx.MockT, i int)
 
-		ExpectedTable interface{}
+		ExpectedTable any
 	}{
 		{
 			Name: "is a no-op when SetupMocks is not provided",
@@ -407,7 +407,7 @@ func TestParseEntryValue(t *testing.T) {
 			entryVal := tableVal.Index(i)
 
 			if mocksField := entryVal.FieldByName("Mocks"); mocksField.IsValid() {
-				mocksField.Set(reflect.New(reflect.TypeOf(Mocks{})))
+				mocksField.Set(reflect.New(reflect.TypeFor[Mocks]()))
 			}
 
 			mockT := mock_testctx.NewMockT(ensure.GoMockController())

--- a/internal/plugins/subject/subject.go
+++ b/internal/plugins/subject/subject.go
@@ -54,7 +54,7 @@ func (t *TablePlugin) ParseEntryType(entryType reflect.Type) (plugins.TableEntry
 func validateSubjectFieldType(subjectStruct *reflect.StructField) error {
 	t := subjectStruct.Type
 
-	if t.Kind() != reflect.Ptr || t.Elem().Kind() != reflect.Struct {
+	if t.Kind() != reflect.Pointer || t.Elem().Kind() != reflect.Struct {
 		return stringerr.Newf("expected %s field to be a pointer to a struct, got %s", id.Subject, t)
 	}
 

--- a/internal/plugins/subject/subject_test.go
+++ b/internal/plugins/subject/subject_test.go
@@ -19,7 +19,7 @@ func TestParseEntryType(t *testing.T) {
 		Name string
 
 		MocksInput *mocks.All
-		Entry      interface{}
+		Entry      any
 
 		ExpectedError error
 	}{
@@ -537,9 +537,9 @@ func TestParseEntryValue(t *testing.T) {
 		Name string
 
 		MocksInput *mocks.All
-		Table      interface{}
+		Table      any
 
-		ExpectedTable interface{}
+		ExpectedTable any
 	}{
 		{
 			Name: "makes no changes when subject is not provided",
@@ -642,7 +642,7 @@ func TestParseEntryValue(t *testing.T) {
 				{
 					Path: "Mocks.Bingo",
 					Mock: &ExampleBingo{},
-					Values: []interface{}{
+					Values: []any{
 						&ExampleBingo{"bingo1"},
 						&ExampleBingo{"bingo2"},
 					},
@@ -682,7 +682,7 @@ func TestParseEntryValue(t *testing.T) {
 				{
 					Path: "Mocks.Bingo",
 					Mock: &ExampleBingo{},
-					Values: []interface{}{
+					Values: []any{
 						&ExampleBingo{"bingo1"},
 						&ExampleBingo{"bingo2"},
 					},
@@ -726,7 +726,7 @@ func TestParseEntryValue(t *testing.T) {
 				{
 					Path: "Mocks.Bingo",
 					Mock: &ExampleBingo{},
-					Values: []interface{}{
+					Values: []any{
 						&ExampleBingo{"bingo1"},
 						&ExampleBingo{"bingo2"},
 					},
@@ -770,7 +770,7 @@ func TestParseEntryValue(t *testing.T) {
 				{
 					Path: "Mocks.Bingo",
 					Mock: &ExampleBingo{},
-					Values: []interface{}{
+					Values: []any{
 						&ExampleBingo{"bingo1"},
 						&ExampleBingo{"bingo2"},
 					},
@@ -778,7 +778,7 @@ func TestParseEntryValue(t *testing.T) {
 				{
 					Path: "Mocks.Hello",
 					Mock: &ExampleHello{},
-					Values: []interface{}{
+					Values: []any{
 						&ExampleHello{"hello1"},
 						&ExampleHello{"hello2"},
 					},
@@ -826,7 +826,7 @@ func TestParseEntryValue(t *testing.T) {
 				{
 					Path: "Mocks.Bingo",
 					Mock: &ExampleBingo{},
-					Values: []interface{}{
+					Values: []any{
 						&ExampleBingo{"bingo1"},
 						&ExampleBingo{"bingo2"},
 					},
@@ -834,7 +834,7 @@ func TestParseEntryValue(t *testing.T) {
 				{
 					Path: "Mocks.Hello",
 					Mock: &ExampleHello{},
-					Values: []interface{}{
+					Values: []any{
 						&ExampleHello{"hello1"},
 						&ExampleHello{"hello2"},
 					},
@@ -876,7 +876,7 @@ func TestParseEntryValue(t *testing.T) {
 				{
 					Path: "Mocks.Composite",
 					Mock: &ExampleComposite{},
-					Values: []interface{}{
+					Values: []any{
 						&ExampleComposite{unique: "composite1"},
 						&ExampleComposite{unique: "composite2"},
 					},
@@ -923,7 +923,7 @@ func TestParseEntryValue(t *testing.T) {
 				{
 					Path: "Mocks.Bingo",
 					Mock: &ExampleBingo{},
-					Values: []interface{}{
+					Values: []any{
 						&ExampleBingo{"bingo1"},
 						&ExampleBingo{"bingo2"},
 					},
@@ -931,7 +931,7 @@ func TestParseEntryValue(t *testing.T) {
 				{
 					Path: "Mocks.Hello",
 					Mock: &ExampleHello{},
-					Values: []interface{}{
+					Values: []any{
 						&ExampleHello{"hello1"},
 						&ExampleHello{"hello2"},
 					},
@@ -973,7 +973,7 @@ func TestParseEntryValue(t *testing.T) {
 				{
 					Path: "Mocks.Composite",
 					Mock: &ExampleComposite{},
-					Values: []interface{}{
+					Values: []any{
 						&ExampleComposite{unique: "composite1"},
 						&ExampleComposite{unique: "composite2"},
 					},
@@ -1030,7 +1030,7 @@ func TestParseEntryValue(t *testing.T) {
 				{
 					Path: "Mocks.Bingo",
 					Mock: &ExampleBingo{},
-					Values: []interface{}{
+					Values: []any{
 						&ExampleBingo{"bingo1"},
 						&ExampleBingo{"bingo2"},
 					},
@@ -1038,7 +1038,7 @@ func TestParseEntryValue(t *testing.T) {
 				{
 					Path: "Mocks.Hello",
 					Mock: &ExampleHello{},
-					Values: []interface{}{
+					Values: []any{
 						&ExampleHello{"hello1"},
 						&ExampleHello{"hello2"},
 					},

--- a/internal/reflectensure/reflectensure_test.go
+++ b/internal/reflectensure/reflectensure_test.go
@@ -14,35 +14,34 @@ func TestIsEnsuringE(t *testing.T) {
 	ensure := ensure.New(t)
 
 	ensure.Run("when provided ensuring.E", func(ensure ensuring.E) {
-		t := reflect.TypeOf(ensuring.E(nil))
+		t := reflect.TypeFor[ensuring.E]()
 		ensure(reflectensure.IsEnsuringE(t)).IsTrue()
 	})
 
 	ensure.Run("when provided pointer to ensuring.E", func(ensure ensuring.E) {
-		e := ensuring.E(nil)
-		t := reflect.TypeOf(&e)
+		t := reflect.TypeFor[*ensuring.E]()
 		ensure(reflectensure.IsEnsuringE(t)).IsFalse()
 	})
 
 	ensure.Run("when provided ensurepkg.Ensure", func(ensure ensuring.E) {
-		t := reflect.TypeOf(ensurepkg.Ensure(nil)) //lint:ignore SA1019 To ensure compatibility
+		t := reflect.TypeFor[ensurepkg.Ensure]() //lint:ignore SA1019 To ensure compatibility
 		ensure(reflectensure.IsEnsuringE(t)).IsTrue()
 	})
 
 	ensure.Run("when provided another type implementing ensuring.E", func(ensure ensuring.E) {
 		type E ensuring.E
-		t := reflect.TypeOf(E(nil))
+		t := reflect.TypeFor[E]()
 		ensure(reflectensure.IsEnsuringE(t)).IsFalse()
 	})
 
 	ensure.Run("when provided another type named E", func(ensure ensuring.E) {
-		type E func(interface{}) *ensuring.Chain
-		t := reflect.TypeOf(E(nil))
+		type E func(any) *ensuring.Chain
+		t := reflect.TypeFor[E]()
 		ensure(reflectensure.IsEnsuringE(t)).IsFalse()
 	})
 
 	ensure.Run("when provided another type in ensuring", func(ensure ensuring.E) {
-		t := reflect.TypeOf(ensuring.Chain{})
+		t := reflect.TypeFor[ensuring.Chain]()
 		ensure(reflectensure.IsEnsuringE(t)).IsFalse()
 	})
 }

--- a/internal/stringerr/stringerr.go
+++ b/internal/stringerr/stringerr.go
@@ -12,7 +12,7 @@ const levelIndentation = "   "
 type stringError string
 
 // Newf creates a formatted string error.
-func Newf(format string, args ...interface{}) error {
+func Newf(format string, args ...any) error {
 	return stringError(fmt.Sprintf(format, args...))
 }
 

--- a/internal/tablerunner/built_table_test.go
+++ b/internal/tablerunner/built_table_test.go
@@ -596,7 +596,7 @@ func TestBuiltTableRun(t *testing.T) {
 	})
 }
 
-func (entry *RunEntry) runTable(ensure ensuring.E, state *[]string, table interface{}) {
+func (entry *RunEntry) runTable(ensure ensuring.E, state *[]string, table any) {
 	*state = []string{}
 
 	builtTable, err := tablerunner.BuildTable(table, entry.Plugins)
@@ -621,7 +621,7 @@ func (entry *RunEntry) runTable(ensure ensuring.E, state *[]string, table interf
 			ctx, innerT := buildTestContext(ensure.GoMockController(), i)
 			innerT.EXPECT().Helper()
 			innerT.EXPECT().Fatalf(gomock.Any(), gomock.Any()).
-				Do(func(msg string, args ...interface{}) {
+				Do(func(msg string, args ...any) {
 					fatals[i] = fmt.Sprintf(msg, args...)
 				}).MaxTimes(1)
 

--- a/internal/tablerunner/tablerunner.go
+++ b/internal/tablerunner/tablerunner.go
@@ -9,7 +9,7 @@ import (
 )
 
 // BuildTable prepares the table to be run, surfacing any errors encountered while parsing the table.
-func BuildTable(rawTable interface{}, tablePlugins []plugins.TablePlugin) (*BuiltTable, error) {
+func BuildTable(rawTable any, tablePlugins []plugins.TablePlugin) (*BuiltTable, error) {
 	tableVal := reflect.ValueOf(rawTable)
 	if tableVal.Kind() != reflect.Array && tableVal.Kind() != reflect.Slice {
 		return nil, stringerr.Newf("Expected a slice or array for the table, got %T", rawTable)
@@ -56,7 +56,7 @@ func unpackStruct(tableType reflect.Type) (reflect.Type, bool, error) {
 		return tableTypeElem, false, nil
 	}
 
-	if tableTypeElem.Kind() == reflect.Ptr && tableTypeElem.Elem().Kind() == reflect.Struct {
+	if tableTypeElem.Kind() == reflect.Pointer && tableTypeElem.Elem().Kind() == reflect.Struct {
 		return tableTypeElem.Elem(), true, nil
 	}
 

--- a/internal/tablerunner/tablerunner_test.go
+++ b/internal/tablerunner/tablerunner_test.go
@@ -42,7 +42,7 @@ func TestBuildTable(t *testing.T) {
 	table := []*struct {
 		Name string
 
-		Table   interface{}
+		Table   any
 		Plugins []plugins.TablePlugin
 
 		ReturnsBuiltTable bool
@@ -118,12 +118,12 @@ func TestBuildTable(t *testing.T) {
 
 		{
 			Name:          "when provided a slice of interfaces",
-			Table:         []interface{}{"Hello", "World"},
+			Table:         []any{"Hello", "World"},
 			ExpectedError: errors.New("Expected entry in table to be a struct or a pointer to a struct, got interface {}"),
 		},
 		{
 			Name:          "when provided an array of interfaces",
-			Table:         [2]interface{}{"Hello", "World"},
+			Table:         [2]any{"Hello", "World"},
 			ExpectedError: errors.New("Expected entry in table to be a struct or a pointer to a struct, got interface {}"),
 		},
 

--- a/internal/testctx/synctest_test.go
+++ b/internal/testctx/synctest_test.go
@@ -18,7 +18,7 @@ func TestSync(t *testing.T) {
 	outerT := mock_testctx.NewMockT(ctrl)
 	outerT.EXPECT().Helper()
 
-	wrapEnsure := func(t testctx.T) interface{} { return fmt.Sprintf("%T", t) }
+	wrapEnsure := func(t testctx.T) any { return fmt.Sprintf("%T", t) }
 	ctx := testctx.New(outerT, wrapEnsure)
 
 	var called bool

--- a/internal/testctx/testctx.go
+++ b/internal/testctx/testctx.go
@@ -10,9 +10,9 @@ import (
 
 // T is a minimal implementation of [testing.T] that may expand whenever a new method is needed.
 type T interface {
-	Logf(format string, args ...interface{})
-	Errorf(format string, args ...interface{})
-	Fatalf(format string, args ...interface{})
+	Logf(format string, args ...any)
+	Errorf(format string, args ...any)
+	Fatalf(format string, args ...any)
 	Run(name string, f func(t *testing.T)) bool
 	Helper()
 	Cleanup(f func())
@@ -23,7 +23,7 @@ var _ T = &testing.T{}
 
 // WrapEnsure is a function that returns the [ensuring.E] for the provided [T].
 // It returns an interface instead of the concrete type to avoid an import cycle.
-type WrapEnsure func(T) interface{}
+type WrapEnsure func(T) any
 
 // Context contains scoped test helpers.
 type Context interface {
@@ -40,7 +40,7 @@ type Context interface {
 	// Ensure returns the [ensuring.E] relating to the in-scope [T].
 	// It returns an interface instead of the concrete type to avoid an import cycle.
 	// It memoizes the value for subsequent calls.
-	Ensure() interface{}
+	Ensure() any
 }
 
 // SyncableContext extends [Context] with the ability to use [synctest.Test] in Go 1.25+.
@@ -58,7 +58,7 @@ type baseContext struct {
 	goMockControllerOnce sync.Once
 
 	wrapEnsure WrapEnsure
-	ensure     interface{}
+	ensure     any
 	ensureOnce sync.Once
 }
 
@@ -101,7 +101,7 @@ func (ctx *baseContext) GoMockController() *gomock.Controller {
 // Ensure returns the [ensuring.E] relating to the in-scope [T].
 // It returns an interface instead of the concrete type to avoid an import cycle.
 // It memoizes the value for subsequent calls.
-func (ctx *baseContext) Ensure() interface{} {
+func (ctx *baseContext) Ensure() any {
 	ctx.t.Helper()
 
 	ctx.ensureOnce.Do(func() {

--- a/internal/testctx/testctx_test.go
+++ b/internal/testctx/testctx_test.go
@@ -18,7 +18,7 @@ func TestNew(t *testing.T) {
 	mockT.EXPECT().Helper().AnyTimes()
 
 	wrappedT := MockT{T: mockT, unique: "hello"}
-	wrapEnsure := func(t testctx.T) interface{} { return t.(MockT).unique + " world" }
+	wrapEnsure := func(t testctx.T) any { return t.(MockT).unique + " world" }
 
 	ctx := testctx.New(wrappedT, wrapEnsure)
 	eq(t, ctx.T().(MockT).unique, "hello")
@@ -41,7 +41,7 @@ func TestRun(t *testing.T) {
 		fn(&testing.T{})
 	})
 
-	wrapEnsure := func(t testctx.T) interface{} { return fmt.Sprintf("%T", t) }
+	wrapEnsure := func(t testctx.T) any { return fmt.Sprintf("%T", t) }
 	ctx := testctx.New(outerT, wrapEnsure)
 
 	var called bool
@@ -153,7 +153,7 @@ func TestEnsure(t *testing.T) {
 		wrappedT := MockT{T: mockT, unique: "hello"}
 
 		callCount := 0
-		wrapEnsure := func(t testctx.T) interface{} {
+		wrapEnsure := func(t testctx.T) any {
 			callCount++
 			return t.(MockT).unique + " world"
 		}
@@ -173,14 +173,14 @@ func TestEnsure(t *testing.T) {
 		mockT.EXPECT().Helper().AnyTimes()
 
 		wrappedT := MockT{T: mockT, unique: "hello"}
-		wrapEnsure := func(t testctx.T) interface{} {
+		wrapEnsure := func(t testctx.T) any {
 			return t.(MockT).unique + " world"
 		}
 
 		ctx := testctx.New(wrappedT, wrapEnsure)
 
 		const numGoroutines = 10
-		ensures := make(chan interface{}, numGoroutines)
+		ensures := make(chan any, numGoroutines)
 
 		var wg sync.WaitGroup
 		for range numGoroutines {
@@ -195,7 +195,7 @@ func TestEnsure(t *testing.T) {
 		close(ensures)
 
 		// Verify it was memoized across all goroutines
-		var first interface{}
+		var first any
 		for e := range ensures {
 			if first == nil {
 				first = e
@@ -209,14 +209,14 @@ func TestEnsure(t *testing.T) {
 	})
 }
 
-func eq(t *testing.T, a, b interface{}) {
+func eq(t *testing.T, a, b any) {
 	t.Helper()
 	if !reflect.DeepEqual(a, b) {
 		t.Fatal(pretty.Sprintf("% #v should equal % #v", a, b))
 	}
 }
 
-func neq(t *testing.T, a, b interface{}) {
+func neq(t *testing.T, a, b any) {
 	t.Helper()
 	if reflect.DeepEqual(a, b) {
 		t.Fatal(pretty.Sprintf("% #v should not equal % #v", a, b))


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Replaced all occurrences of `interface{}` with the `any` type alias throughout the codebase for Go 1.23 compatibility

- Modernized reflection operations by replacing `reflect.TypeOf()` calls with `reflect.TypeFor[]()` generic function for type-safe reflection

- Updated `reflect.Ptr` constant to `reflect.Pointer` for Go 1.23 compatibility across multiple files

- Replaced `sort.Slice()` with `slices.SortFunc()` using `cmp.Compare()` for more idiomatic sorting

- Simplified type assertions by removing intermediate variable declarations when using `reflect.TypeFor[]()` generics

- Updated struct field definitions, function signatures, and variadic parameters to use modern Go conventions

- Updated TODO comments and documentation to reflect Go 1.23 modernization efforts

- Updated mock generation templates and expected test fixtures to use `any` instead of `interface{}`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["interface{} type"] -- "replace with" --> B["any type alias"]
  C["reflect.TypeOf() calls"] -- "replace with" --> D["reflect.TypeFor[] generics"]
  E["reflect.Ptr constant"] -- "update to" --> F["reflect.Pointer constant"]
  G["sort.Slice() function"] -- "replace with" --> H["slices.SortFunc() with cmp"]
  B --> I["Go 1.23 compatible code"]
  D --> I
  F --> I
  H --> I
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>58 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>struct_fields_test.go</strong><dd><code>Modernize reflect type operations to Go 1.23 generics</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/plugins/internal/iterate/struct_fields_test.go

<ul><li>Replaced <code>interface{}</code> with <code>any</code> type alias throughout test file<br> <li> Replaced <code>reflect.TypeOf()</code> calls with <code>reflect.TypeFor[]()</code> generic <br>function for type retrieval<br> <li> Updated interface type assertions to use <code>reflect.TypeFor[interface{ </code><br><code>B() int }]()</code> instead of <code>reflect.TypeOf((*interface{ B() int </code><br><code>})(nil)).Elem()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-59583e2a6f58eed99423ca17f72fdef99e50eedfb174c7060bf1ac09799a2be0">+130/-130</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mock_testctx.go</strong><dd><code>Replace interface{} with any type alias in mock</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/mocks/mock_testctx/mock_testctx.go

<ul><li>Replaced all <code>interface{}</code> type declarations with <code>any</code> alias<br> <li> Updated slice literals from <code>[]interface{}</code> to <code>[]any</code><br> <li> Changed function parameter and return types from <code>interface{}</code> to <code>any</code></ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-10e950a6c7fcf99ce6b8e552e093417c06e41ce0ce0aa646ca55751be97c8abc">+54/-54</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>run_table_test.go</strong><dd><code>Modernize interface{} to any in table test utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ensuring/run_table_test.go

<ul><li>Replaced <code>interface{}</code> with <code>any</code> type alias in function signatures and <br>struct fields<br> <li> Updated variadic parameter types from <code>...interface{}</code> to <code>...any</code></ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-9d9966b47b80cbea3c1b31434e44afe47569953912c2e4798cbd552a0cc0b69e">+21/-21</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mocks_test.go</strong><dd><code>Update mock tests to use reflect.TypeFor generics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/plugins/internal/mocks/mocks_test.go

<ul><li>Replaced <code>reflect.TypeOf()</code> calls with <code>reflect.TypeFor[]()</code> generic <br>function<br> <li> Updated interface type assertions to use <br><code>reflect.TypeFor[InterfaceName]()</code> pattern</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-985d5177707926795b9044d5f48b15599d7d6036b5c46eae110d5e8f0a4ab168">+25/-25</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mock_ensuring.go</strong><dd><code>Replace interface{} with any in mock_ensuring</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

exp/entable/internal/mocks/github.com/JosiahWitt/ensure/mock_ensuring/mock_ensuring.go

<ul><li>Replaced <code>interface{}</code> with <code>any</code> type alias throughout mock file<br> <li> Updated slice literals and function signatures to use <code>any</code> instead of <br><code>interface{}</code></ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-76d0bf7884240cf6bd8c364549796e4c44550170373a6f431d191cb728b8a69f">+21/-21</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chain.go</strong><dd><code>Modernize chain.go to Go 1.23 conventions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ensuring/chain.go

<ul><li>Replaced <code>interface{}</code> with <code>any</code> type alias in function signatures and <br>parameters<br> <li> Changed <code>reflect.Ptr</code> to <code>reflect.Pointer</code> constant for Go 1.23 <br>compatibility<br> <li> Updated function return types from <code>[]interface{}</code> to <code>[]any</code></ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-201ed9ff234e44b80a9478a4e0e6c06a80e10d496226dafffd4222bf19463595">+14/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mock_fswrite.go</strong><dd><code>Replace interface{} with any in fswrite mock</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/ensure/internal/mocks/mock_fswrite/mock_fswrite.go

<ul><li>Replaced <code>interface{}</code> with <code>any</code> type alias in all mock method signatures<br> <li> Updated slice literals from <code>[]interface{}</code> to <code>[]any</code></ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-2b01af24f2abf67e6154ea6c03ed67a0a707375c124012361aa3e9ef12f3c436">+14/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mocks_test.go</strong><dd><code>Modernize mocks_test.go to use any type alias</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/plugins/mocks/mocks_test.go

<ul><li>Replaced <code>interface{}</code> with <code>any</code> type alias in struct fields and slice <br>literals<br> <li> Updated test table entries to use <code>any</code> instead of <code>interface{}</code></ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-8885fa8095f4f181f358d0059fde19a6f94e27daad76525ee8ea0f4c054ea197">+14/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>subject_test.go</strong><dd><code>Replace interface{} with any in subject_test.go</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/plugins/subject/subject_test.go

<ul><li>Replaced <code>interface{}</code> with <code>any</code> type alias in struct fields and slice <br>literals<br> <li> Updated test table entries to use <code>any</code> instead of <code>interface{}</code></ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-a65fe78ac37afd30572f514218309c2439d921f75256da691272453605c5552c">+16/-16</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chain_test.go</strong><dd><code>Modernize chain_test.go to use any type alias</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ensuring/chain_test.go

<ul><li>Replaced <code>interface{}</code> with <code>any</code> type alias in function signatures and <br>struct fields<br> <li> Updated test helper function parameters to use <code>any</code> instead of <br><code>interface{}</code></ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-462770f49205034e73cc1e848a4a8193333b936e0e573631d325595c16f86a99">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ifacereader_test.go</strong><dd><code>Modernize sorting to use slices.SortFunc with cmp</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/ensure/internal/ifacereader/ifacereader_test.go

<ul><li>Added imports for <code>cmp</code> and <code>slices</code> packages<br> <li> Replaced <code>sort.Slice()</code> with <code>slices.SortFunc()</code> using <code>cmp.Compare()</code><br> <li> Updated TODO comments to reflect Go 1.23 modernization instead of Go <br>1.18</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-9ee93ffc82c21687361811183aeeabb849e224a45f2fd0bddde1db68cb22a272">+9/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mock_mockwrite.go</strong><dd><code>Replace interface{} with any in mockwrite mock</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/ensure/internal/mocks/mock_mockwrite/mock_mockwrite.go

<ul><li>Replaced <code>interface{}</code> with <code>any</code> type alias in mock method signatures<br> <li> Updated slice literals from <code>[]interface{}</code> to <code>[]any</code></ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-8e096584780bbf3d6fd945da5c5d153b39bf60d49ec0944026539d76793ace14">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>template.go</strong><dd><code>Modernize mockgen template to use any type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/ensure/internal/mockgen/template.go

<ul><li>Replaced <code>interface{}</code> with <code>any</code> in template string literals<br> <li> Updated mock input signature generation to use <code>any</code> instead of <br><code>interface{}</code><br> <li> Changed variadic parameter type from <code>...interface{}</code> to <code>...any</code></ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-3e9eedd3f69890cb9f6b9bfc634a4eb5b638a68ddea67a61e397bc64e64299fb">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mock_fs.go</strong><dd><code>Replace interface{} with any in mock_fs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/ensure/internal/mocks/io/mock_fs/mock_fs.go

<ul><li>Replaced <code>interface{}</code> with <code>any</code> type alias in mock method signatures<br> <li> Updated slice literals from <code>[]interface{}</code> to <code>[]any</code></ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-173fed6c14e3e189a8e4ee895393bcf4e365a4eab609b26f4b05d21db135f7b9">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>testctx_test.go</strong><dd><code>Modernize testctx_test.go to use any type alias</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/testctx/testctx_test.go

<ul><li>Replaced <code>interface{}</code> with <code>any</code> type alias in function signatures and <br>variable declarations<br> <li> Updated channel type from <code>chan interface{}</code> to <code>chan any</code></ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-e71872f0e92a01dda9d7513b18015aedb14c9741c6db7890fdc99673928eb8c8">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>methods_test.go</strong><dd><code>Replace interface{} with any in integration tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/integration_test_suite/methods_test.go

<ul><li>Replaced <code>interface{}</code> with <code>any</code> type alias in function signatures<br> <li> Updated variadic parameter types from <code>...interface{}</code> to <code>...any</code></ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-4c12c78f044c00208d4184f70461ae7e8df3006966ad73e3a8661c909513aa34">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>struct_fields.go</strong><dd><code>Modernize struct_fields.go to Go 1.23 conventions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/plugins/internal/iterate/struct_fields.go

<ul><li>Removed TODO comment about Go 1.17 minimum version and replaced <br><code>field.PkgPath != ""</code> check with <code>!field.IsExported()</code><br> <li> Changed <code>reflect.Ptr</code> to <code>reflect.Pointer</code> constant for Go 1.23 <br>compatibility<br> <li> Updated variadic parameter type from <code>...interface{}</code> to <code>...any</code></ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-f389886e0f141fc0f4b6b373d9f3bbf3d6957a08f1614c0ab07bb7024ef3e48d">+5/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mocks.go</strong><dd><code>Update mocks.go to use reflect.TypeFor generics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/plugins/mocks/mocks.go

<ul><li>Replaced <code>reflect.TypeOf(&gomock.Controller{})</code> with <br><code>reflect.TypeFor[*gomock.Controller]()</code><br> <li> Changed <code>reflect.Ptr</code> to <code>reflect.Pointer</code> constant for Go 1.23 <br>compatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-b7b6574fab2f94c03c83f8c39b6edc0058938611bd3b376987a255211aa96d48">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mock_mockgen.go</strong><dd><code>Replace interface{} with any in mock_mockgen</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/ensure/internal/mocks/mock_mockgen/mock_mockgen.go

<ul><li>Replaced <code>interface{}</code> with <code>any</code> type alias in mock method signatures<br> <li> Updated slice literals from <code>[]interface{}</code> to <code>[]any</code></ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-b097d2122ca44eea17ebeca726379331de70ab4f01c554f0527eec383fedcaa8">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mock_ifacereader.go</strong><dd><code>Replace interface{} with any in mock_ifacereader</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/ensure/internal/mocks/mock_ifacereader/mock_ifacereader.go

<ul><li>Replaced <code>interface{}</code> with <code>any</code> type alias in mock method signatures<br> <li> Updated slice literals from <code>[]interface{}</code> to <code>[]any</code></ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-5c9bde67897d3c6db62758b8c3b14dde27f5863b81b1a85c0cf509434ec52733">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mock_ensurefile.go</strong><dd><code>Replace interface{} with any in mock_ensurefile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/ensure/internal/mocks/mock_ensurefile/mock_ensurefile.go

<ul><li>Replaced <code>interface{}</code> with <code>any</code> type alias in mock method signatures<br> <li> Updated slice literals from <code>[]interface{}</code> to <code>[]any</code></ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-eb1b58c5ecdceaca660726287b46e7e994b0388b34ce1203a6ddb350dfc5f08e">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>testctx.go</strong><dd><code>Modernize testctx.go to use any type alias</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/testctx/testctx.go

<ul><li>Replaced <code>interface{}</code> with <code>any</code> type alias in interface method <br>signatures<br> <li> Updated function return types and variable declarations to use <code>any</code></ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-7b74dbc13b1ef23ca599416bb0a4688fe8ed32b2dfb996f2232fd418e74f4b8f">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>reflectensure_test.go</strong><dd><code>Update reflectensure_test.go to use reflect.TypeFor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/reflectensure/reflectensure_test.go

<ul><li>Replaced <code>reflect.TypeOf()</code> calls with <code>reflect.TypeFor[]()</code> generic <br>function<br> <li> Simplified type assertions by removing intermediate variable <br>declarations</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-6c09573186181c04f04b1fecf760ec5225b171d92b8d7968b9abfb14ce234dcc">+7/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ensuring.go</strong><dd><code>Modernize ensuring.go to use any type alias</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ensuring/ensuring.go

<ul><li>Replaced <code>interface{}</code> with <code>any</code> type alias in function signatures and <br>struct fields<br> <li> Updated function return types and variable declarations to use <code>any</code></ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-4e183b74c7546428c8d1119946980f3f467e446b4ea02885dc7222eef9604265">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>setupmocks_test.go</strong><dd><code>Modernize setupmocks_test.go to use any and TypeFor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/plugins/setupmocks/setupmocks_test.go

<ul><li>Replaced <code>interface{}</code> with <code>any</code> type alias in struct fields<br> <li> Updated <code>reflect.TypeOf(Mocks{})</code> to <code>reflect.TypeFor[Mocks]()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-767b0ef41fc8355ea1ea776cda983993e71c32d4d267e77e8bb8edbc77e26504">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>builtin.go</strong><dd><code>Replace interface{} with any in builtin scenario</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/ensure/internal/ifacereader/scenarios/builtin/builtin.go

<ul><li>Replaced <code>interface{}</code> with <code>any</code> in interface method signatures<br> <li> Updated type string representations from <code>interface{}</code> to <code>any</code></ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-7684154f3476a94600e733e6ef971138c99abfdd082d2f58cb1b99345fc0f57a">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tablerunner.go</strong><dd><code>Modernize tablerunner.go to Go 1.23 conventions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/tablerunner/tablerunner.go

<ul><li>Replaced <code>interface{}</code> with <code>any</code> type alias in function parameters<br> <li> Changed <code>reflect.Ptr</code> to <code>reflect.Pointer</code> constant for Go 1.23 <br>compatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-8b7c49da070833cd16b79c77cd93aed01478c2942252a14780d314b0fd590365">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tablerunner_test.go</strong><dd><code>Replace interface{} with any in tablerunner_test.go</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/tablerunner/tablerunner_test.go

<ul><li>Replaced <code>interface{}</code> with <code>any</code> type alias in struct fields and slice <br>literals<br> <li> Updated test table entries to use <code>any</code> instead of <code>interface{}</code></ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-2ba04366c6401dec482465281abce03daca13ea129b69c2bb7be6b1d51816168">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>built_table_test.go</strong><dd><code>Replace interface{} with any in built_table_test.go</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/tablerunner/built_table_test.go

<ul><li>Replaced <code>interface{}</code> with <code>any</code> type alias in function parameters<br> <li> Updated variadic parameter types from <code>...interface{}</code> to <code>...any</code></ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-8edda71095fa5dc7416d5b2d6a21e4dd28b898c0bce3d1d862c778ac16c4a599">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>uniqpkg.go</strong><dd><code>Modernize sorting to use slices.SortFunc with cmp</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/ensure/internal/uniqpkg/uniqpkg.go

<ul><li>Added imports for <code>cmp</code> and <code>slices</code> packages<br> <li> Replaced <code>sort.Slice()</code> with <code>slices.SortFunc()</code> using <code>cmp.Compare()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-ef56c4b045f913e01d7b4bd2b4e13a934b2616a860de49cd001511a1fec5a984">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>synctest.go</strong><dd><code>Replace interface{} with any in synctest.go</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ensuring/synctest.go

- Replaced `interface{}` with `any` type alias in function parameter


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-b03c98be78e8000bbb828c5b684757635479a7fbc4100d0513c5cab088ec6c7c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>synctest_test.go</strong><dd><code>Replace interface{} with any in synctest_test.go</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ensuring/synctest_test.go

- Replaced `interface{}` with `any` type alias in function signature


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-05fae6242a681ef1f8156fbd041f14574d912ba8092402c32d07f42a8c6243a2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ensurefile_test.go</strong><dd><code>Replace interface{} with any in ensurefile_test.go</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/ensure/internal/ensurefile/ensurefile_test.go

<ul><li>Replaced <code>interface{}</code> with <code>any</code> type alias in map type declaration</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-3b4b4693e61aa560fd6da7a6429e9c9b24739ea16c314185586778fbbf23255a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>example1.go</strong><dd><code>Update example1.go to use reflect.TypeFor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/ensure/internal/ifacereader/fixtures/externaltypes/example1/example1.go

<ul><li>Replaced <code>reflect.TypeOf(String(""))</code> with <code>reflect.TypeFor[String]()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-836020faed79ac5ea05866c0ba45625ae351e0b02e56a6ab1bcbd537516df06b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>go125_test.go</strong><dd><code>Replace interface{} with any type alias</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/integration_test_suite/go125_test.go

- Replaced `interface{}` with `any` type alias in function parameter


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-eef4741c8e9413819aac3c06e5361070c58a571bb373615a60482c81fd662751">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ensuring_test.go</strong><dd><code>Replace interface{} with any type alias</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ensuring/ensuring_test.go

<ul><li>Replaced <code>interface{}</code> return type with <code>any</code> in <code>wrapEnsure</code> function</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-58f5c50ba3f7e620b9179a530356de5250d1effb27a387e6c543aa38493b3974">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>run_table.go</strong><dd><code>Replace interface{} with any type alias</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ensuring/run_table.go

<ul><li>Replaced <code>interface{}</code> with <code>any</code> type alias in <code>RunTableByIndex</code> method <br>parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-b6220281087ac7f808f2b0aecfe678be562b80c93e576285b27ff67c7bbdd949">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>subject.go</strong><dd><code>Update reflect.Ptr to reflect.Pointer constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/plugins/subject/subject.go

<ul><li>Replaced <code>reflect.Ptr</code> with <code>reflect.Pointer</code> constant for Go 1.23 <br>compatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-ff4a403059650773fec7b51f7ef6dab5a6b4b4c54e40b8fbb721f465e111d61f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>synctest_test.go</strong><dd><code>Replace interface{} with any type alias</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/testctx/synctest_test.go

- Replaced `interface{}` return type with `any` in function literal


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-8ba4e8f345e160a80cb7c6290579834e59874c6029562dfe08ede4cfb936add4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>testhelper.go</strong><dd><code>Replace interface{} with any type alias in struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/plugins/internal/testhelper/testhelper.go

<ul><li>Replaced <code>interface{}</code> with <code>any</code> type alias in struct fields <code>Mock</code> and <br><code>Values</code></ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-ba8447f58db4c3d4253aa6accb2a996db1ff040d33cbb3a343bc082992e4ac51">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>example2.go</strong><dd><code>Use reflect.TypeFor generic function for type reflection</code>&nbsp; </dd></summary>
<hr>

cmd/ensure/internal/ifacereader/fixtures/externaltypes/example2/example2.go

<ul><li>Replaced <code>reflect.TypeOf(Float64(0))</code> with <code>reflect.TypeFor[Float64]()</code> <br>for Go 1.23 generic reflection</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-18cc1cc0060a21d01467d42f55d8731de1750ff75d70e92af2eff41889f5ebee">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>base.go</strong><dd><code>Replace interface{} with any type alias</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/ensure/internal/ifacereader/scenarios/base/base.go

<ul><li>Replaced <code>interface{}</code> with <code>any</code> type alias in struct field <code>Fixture</code></ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-10c57873ec0073615030d6c74c5f23e43638bde743759e8c7007ae0552828903">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>stringerr.go</strong><dd><code>Replace interface{} with any type alias in variadic args</code>&nbsp; </dd></summary>
<hr>

internal/stringerr/stringerr.go

<ul><li>Replaced <code>...interface{}</code> with <code>...any</code> in variadic parameter of <code>Newf</code> <br>function</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-fa8682f83237dc12eab7ae8862ffac9f4a4f2ff1461cce06283c6087b1df40b6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>emptyiface.go</strong><dd><code>Replace interface{} with any type alias</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/ensure/internal/ifacereader/fixtures/emptyiface/emptyiface.go

- Replaced `interface{}` with `any` type alias in type definition


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-9d23b4fc17eb2525bd18f427b7fe4c58b1c58325e697e6890c8c965871ad8e92">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pkg1.expected</strong><dd><code>Replace interface{} with any in mock scenarios</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/ensure/internal/mockgen/scenarios/multiple_interfaces/pkg1.expected

<ul><li>Replaced multiple instances of <code>interface{}</code> with <code>any</code> type alias <br>throughout mock code<br> <li> Updated slice type declarations and function parameters to use <code>any</code></ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-58fe3f9350fc83ae0a0df99ee57f500d383e1e35c2e600d5eb95b5f7cd9c9dd8">+11/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pkg1.expected</strong><dd><code>Replace interface{} with any in mock scenarios</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/ensure/internal/mockgen/scenarios/single_interface_multiple_methods/pkg1.expected

<ul><li>Replaced multiple instances of <code>interface{}</code> with <code>any</code> type alias in mock <br>code</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-77fdea9cf6a28709c9f40f701db46863b0555af36095646f4440c5be1399d63b">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pkg1.expected</strong><dd><code>Replace interface{} with any in generic mock scenarios</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/ensure/internal/mockgen/scenarios/generics_multiple_type_params/pkg1.expected

<ul><li>Replaced multiple instances of <code>interface{}</code> with <code>any</code> type alias in <br>generic mock code</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-13b88fc586c1316014528789996dedb917cbf3a104db29dc120c228a4d3e53e0">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pkg1.expected</strong><dd><code>Replace interface{} with any in variadic mock scenarios</code>&nbsp; &nbsp; </dd></summary>
<hr>

cmd/ensure/internal/mockgen/scenarios/single_method_variadic_input/pkg1.expected

<ul><li>Replaced multiple instances of <code>interface{}</code> with <code>any</code> type alias in mock <br>code with variadic inputs</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-8aa44d23c061fba2989b2cbb463086982f17247e7d361608de0872acd9ff29e2">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pkg1.expected</strong><dd><code>Replace interface{} with any in mock scenarios</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/ensure/internal/mockgen/scenarios/single_method_unnamed_inputs/pkg1.expected

<ul><li>Replaced multiple instances of <code>interface{}</code> with <code>any</code> type alias in mock <br>code</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-58ea95e216372065a9ce443e505691baf5c40176544059f635e09a09ff7d894a">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pkg1.expected</strong><dd><code>Replace interface{} with any in mock scenarios</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/ensure/internal/mockgen/scenarios/single_method_named_outputs/pkg1.expected

<ul><li>Replaced multiple instances of <code>interface{}</code> with <code>any</code> type alias in mock <br>code</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-8de208bb8308b016e03e0dbc7b3bfc5815952b2014f6a7be66b0fc2c2be76a87">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pkg1.expected</strong><dd><code>Replace interface{} with any in mock scenarios</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/ensure/internal/mockgen/scenarios/single_method_external_imports_clash_with_required/pkg1.expected

<ul><li>Replaced multiple instances of <code>interface{}</code> with <code>any</code> type alias in mock <br>code with external imports</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-86b591478c2e82abc2dc75aa77daddf5944c31ddef9fdc34a5a65393177d8e34">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pkg1.expected</strong><dd><code>Replace interface{} with any in mock scenarios</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/ensure/internal/mockgen/scenarios/single_method_multiple_params/pkg1.expected

<ul><li>Replaced multiple instances of <code>interface{}</code> with <code>any</code> type alias in mock <br>code</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-de2d716af1fa1cdf0576c1f297d8b5aee6bcff417ad3ed5cb113d53e2067a852">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pkg1.expected</strong><dd><code>Replace interface{} with any in mock scenarios</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/ensure/internal/mockgen/scenarios/single_method_external_imports/pkg1.expected

<ul><li>Replaced multiple instances of <code>interface{}</code> with <code>any</code> type alias in mock <br>code with external imports</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-c83448cd22003bacf738f0a1d6cb0ae76b5bdf5a0f0ec35e9b13d69b89ac26e9">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pkg1.expected</strong><dd><code>Replace interface{} with any in mock scenarios</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/ensure/internal/mockgen/scenarios/single_method_external_imports_with_aliases/pkg1.expected

<ul><li>Replaced multiple instances of <code>interface{}</code> with <code>any</code> type alias in mock <br>code with aliased imports</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-07524c415bb4200992e702ebe02fec288e933c7e32e8ae0aa94e7c9214d92452">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pkg1.expected</strong><dd><code>Replace interface{} with any in mock scenarios</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/ensure/internal/mockgen/scenarios/single_method_no_imports/pkg1.expected

<ul><li>Replaced multiple instances of <code>interface{}</code> with <code>any</code> type alias in mock <br>code</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-504e458528e87575fd092e09a8e4341e7d1d12cd6f8e234b30597efdf6bf54af">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pkg1.expected</strong><dd><code>Replace interface{} with any in generic mock scenarios</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/ensure/internal/mockgen/scenarios/generics_single_type_param/pkg1.expected

<ul><li>Replaced multiple instances of <code>interface{}</code> with <code>any</code> type alias in <br>generic mock code</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-224096fa8cd0f24694d474bb9a57bc168ca8a108befe0fbde61862398708dfa9">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>noop.expected</strong><dd><code>Replace interface{} with any in mock scenarios</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/ensure/internal/mockgen/scenarios/single_method_no_params/noop.expected

<ul><li>Replaced multiple instances of <code>interface{}</code> with <code>any</code> type alias in mock <br>code</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-3e6933cb0729bd57bd13a6e63c33f5ab38ff5ed2e69e3b56bf2411039ad65e2c">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pkg1.expected</strong><dd><code>Replace interface{} with any in mock scenarios</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/ensure/internal/mockgen/scenarios/enhanced_matcher_failures_disabled/pkg1.expected

<ul><li>Replaced multiple instances of <code>interface{}</code> with <code>any</code> type alias in mock <br>code</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-9c8bd788f7ff7e369c9650aa4a19ceeff9e281d20304d36a1f2440ef65f53534">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>go.mod</strong><dd><code>Update TODO comment in generics module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/ensure/internal/ifacereader/fixtures/generics/go.mod

<ul><li>Updated TODO comment to clarify the reason for nested module structure<br> <li> Changed from referencing Go 1.18 support to explaining dependency on <br>golang.org/x/exp/constraints</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/ensure/pull/98/files#diff-6a3abb9ee89864a38235edd31dff98a8e2ff2c3922f63b9b0cd85dccc17134ce">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

